### PR TITLE
Add console logging for Peer ID button clicks

### DIFF
--- a/printshop.js
+++ b/printshop.js
@@ -345,11 +345,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (setPeerIdBtn) {
         setPeerIdBtn.addEventListener('click', () => {
+            // Adding a log to confirm the click handler is firing and what value is being read.
+            console.log(`setPeerIdBtn clicked. Input ID: '${shopPeerIdInput ? shopPeerIdInput.value : "N/A"}'`);
             const requestedId = shopPeerIdInput ? shopPeerIdInput.value.trim() : null;
             initializeShopPeer(requestedId);
         });
     } else {
-        console.error("Set Peer ID button not found.");
+        // This error is crucial. If it appears, the HTML is missing the button or has a wrong ID.
+        console.error("CRITICAL: Set Peer ID button (setPeerIdBtn) not found in the DOM. Click events will not work.");
     }
+    // This sets the initial state. If it remains this state after a click, the event handler above did not run or failed to change the state.
     updateShopPeerStatus("Ready to set Peer ID or auto-generate.", "pending", "Not Set");
 });


### PR DESCRIPTION
This change adds diagnostic console.log statements to help determine if the 'Set/Refresh ID' button click handler is being correctly invoked.

If the button is clicked and the corresponding log appears in the console, it indicates the event listener is attached and firing. If the log doesn't appear, it suggests the button element might not be found in the DOM, likely due to an issue in the HTML (e.g., incorrect ID or missing element).

This is a step towards resolving an issue where the Peer ID display might not be updating correctly after user input.