### PR TITLE
feat: Update sticker creation page UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,12 +47,28 @@
     <main class="container mx-auto p-4 sm:p-6 lg:p-8 bg-white shadow-xl rounded-lg my-8">
         <div class="flex justify-between items-center mb-6">
             <h1 class="text-3xl font-bold text-center text-gray-700">Custom Sticker Editor & Secure Pay</h1>
-            <a href="/orders.html" class="text-splotch-red hover:underline p-2 border-2 border-dashed border-pink-500 rounded-lg">View Order History</a>
+            <a href="/orders.html" class="bg-splotch-red hover:brightness-110 text-white font-semibold py-2 px-4 rounded-full">View Order History</a>
         </div>
 
         <!-- PeerJS Connection Status -->
         <div id="peerjs-status-container" class="mb-4 p-3 rounded-md text-sm text-white bg-gray-400" style="visibility: hidden; text-align: center;">
             PeerJS Status: Initializing...
+        </div>
+
+        <!-- UPLOAD STICKER FILE -->
+        <div class="field mb-6">
+            <label class="label text-sm font-medium text-gray-700">Upload Sticker Design Image:</label>
+            <div class="control">
+                <input
+                    class="input mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100"
+                    id="file"
+                    name="file"
+                    type="file"
+                    accept="image/*"
+                />
+                <span id="fileNameDisplay" class="text-sm text-gray-600 ml-2"></span>
+            </div>
+             <p class="text-xs text-gray-500 mt-1" style="font-family: var(--font-baumans);">This is the main image for your sticker design.</p>
         </div>
 
         <!-- Canvas for Image Editing -->
@@ -70,8 +86,8 @@
             <button id="rotateLeftBtn" title="Rotate Left 90°">Rotate Left</button>
             <button id="rotateRightBtn" title="Rotate Right 90°">Rotate Right</button>
             <div class="flex flex-col">
-                <label for="resizeSlider" class="text-sm text-center">Scale: <span id="resizeValue">100%</span></label>
-                <input type="range" id="resizeSlider" min="10" max="200" value="100" class="w-full">
+                <label for="resizeSlider" class="text-sm text-center">Size: <span id="resizeValue">3.0 in</span></label>
+                <input type="range" id="resizeSlider" min="1" max="8" value="3" step="0.1" class="w-full">
             </div>
             <button id="startCropBtn" title="Crop to Center 50%">Crop (Center 50%)</button>
             <button id="grayscaleBtn" title="Apply Grayscale Filter">Grayscale</button>
@@ -249,20 +265,6 @@
                         <input class="input mt-1 block w-full" id="postalCode" name="postalCode" type="text" placeholder="73101" required />
                     </div>
                 </div>
-            </div>
-            <div class="field">
-                <label class="label text-sm font-medium text-gray-700" for="file">Upload Sticker Design Image:</label>
-                <div class="control">
-                    <input
-                        class="input mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100"
-                        id="file"
-                        name="file"
-                        type="file"
-                        accept="image/*"
-                    />
-                    <span id="fileNameDisplay" class="text-sm text-gray-600 ml-2"></span>
-                </div>
-                 <p class="text-xs text-gray-500 mt-1" style="font-family: var(--font-baumans);">This is the main image for your sticker design.</p>
             </div>
             <!-- Square Card Payment Element -->
             <div id="card-container" class="p-3 border rounded-md bg-white shadow-sm min-h-[50px]"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "vite": "^5.1.4"
       },
       "devDependencies": {
+        "@faker-js/faker": "^8.4.1",
         "@playwright/test": "^1.45.0",
         "autoprefixer": "^10.4.21",
         "image-size": "^1.1.1",
@@ -1350,6 +1351,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.4.1.tgz",
+      "integrity": "sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=6.14.13"
       }
     },
     "node_modules/@hexagon/base64": {

--- a/src/index.js
+++ b/src/index.js
@@ -110,11 +110,9 @@ async function BootStrap() {
     if (sepiaBtnEl) sepiaBtnEl.addEventListener('click', toggleSepiaFilter);
     if (resizeSliderEl) {
         resizeSliderEl.addEventListener('input', (e) => {
-            const percentage = parseInt(e.target.value, 10);
-            if(resizeValueEl) resizeValueEl.textContent = `${percentage}%`;
-            // For raster images, we can apply this in real-time.
-            // For vector redraws, this could be slow, but we'll try it.
-            handleResize(percentage);
+            const inches = parseFloat(e.target.value);
+            if(resizeValueEl) resizeValueEl.textContent = `${inches.toFixed(1)} in`;
+            handleStandardResize(inches);
         });
     }
     if (startCropBtnEl) startCropBtnEl.addEventListener('click', handleCrop);
@@ -1051,21 +1049,6 @@ function handleStandardResize(targetInches) {
     if (currentMaxWidthPixels <= 0) return;
 
     const scale = targetPixels / currentMaxWidthPixels;
-    const percentage = scale * 100;
-
-    // Update the slider and call the main resize handler
-    const resizeSliderEl = document.getElementById('resizeSlider');
-    const resizeValueEl = document.getElementById('resizeValue');
-    if (resizeSliderEl) resizeSliderEl.value = percentage;
-    if (resizeValueEl) resizeValueEl.textContent = `${Math.round(percentage)}%`;
-
-    handleResize(percentage);
-}
-
-function handleResize(percentage) {
-    if (isNaN(percentage) || percentage <= 0) return;
-
-    const scale = percentage / 100;
 
     if (basePolygons.length > 0) {
         // SVG Vector Resizing - always scale from the original


### PR DESCRIPTION
This commit introduces several UI improvements to the sticker creation page:

1.  **Size Slider:** The 'Scale' slider has been replaced with a 'Size' slider. This allows users to set the sticker's maximum dimension directly in inches, providing a more intuitive user experience. The underlying logic has been updated to handle resizing based on inches instead of a percentage.

2.  **Button Styling:** The 'View Order History' link has been restyled to match the appearance of other primary action buttons, creating a more consistent and polished look and feel.

3.  **Layout Improvement:** The 'Upload Sticker Design Image' input has been moved from the payment form to a more prominent position directly above the sticker preview canvas. This improves the workflow by prompting the user to upload an image earlier in the process.