### PR TITLE
fix: Prevent canvas redraw on page load without an image

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -150,8 +150,11 @@ async function BootStrap() {
         unitToggle.addEventListener('change', (e) => {
             isMetric = e.target.checked;
             updateUnitUI(isMetric);
-            calculateAndUpdatePrice(); // Re-calculate and re-render with new units
-            redrawAll(); // Also redraw the on-canvas indicator
+            // Only redraw if there's something to draw
+            if (originalImage || currentPolygons.length > 0) {
+                calculateAndUpdatePrice();
+                redrawAll();
+            }
         });
     }
 


### PR DESCRIPTION
This commit fixes a bug where canvas drawing functions could be called prematurely when the unit (in/mm) was toggled before an image was loaded. This would lead to an `IndexSizeError` because the canvas dimensions were not yet properly established.

The fix adds a guard to the `unitToggle` event listener to ensure that the `calculateAndUpdatePrice` and `redrawAll` functions are only executed if an image or SVG has been loaded into the editor.