### PR TITLE
Fix CLI test script to prevent deletion of production database

### DIFF
--- a/server/cli.js
+++ b/server/cli.js
@@ -12,7 +12,8 @@ const __dirname = path.dirname(__filename);
 const program = new Command();
 
 const defaultData = { orders: [], users: {}, credentials: {} };
-const db = await JSONFilePreset(path.join(__dirname, 'db.json'), defaultData);
+const dbPath = process.env.DB_PATH || path.join(__dirname, 'db.json');
+const db = await JSONFilePreset(dbPath, defaultData);
 
 program
     .name('printshop-cli')

--- a/server/env.example
+++ b/server/env.example
@@ -2,6 +2,8 @@
 PORT=3000
 BASE_URL="http://localhost:5173"
 NODE_ENV="development"
+# Path to the LowDB JSON database file. Defaults to server/db.json if not set.
+DB_PATH="server/db.json"
 
 # Square Credentials
 SQUARE_ACCESS_TOKEN="YOUR_SANDBOX_ACCESS_TOKEN"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -17,15 +17,12 @@
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
         "express-rate-limit": "^7.5.1",
-        "express-session": "^1.17.3",
         "express-validator": "^7.2.1",
-        "file-type": "^21.0.0",
         "googleapis": "^140.0.1",
         "image-size": "^1.2.1",
         "jose": "^6.0.12",
         "jsonwebtoken": "^9.0.2",
         "lowdb": "^7.0.1",
-        "lusca": "^1.7.0",
         "multer": "^2.0.2",
         "node-telegram-bot-api": "^0.66.0",
         "nodemailer": "^6.9.14",
@@ -34,6 +31,7 @@
         "tiny-csrf": "1.1.6"
       },
       "devDependencies": {
+        "file-type": "^21.0.0",
         "jest": "^29.7.0",
         "jest-mock-extended": "^3.0.7",
         "supertest": "^7.0.0"
@@ -1342,6 +1340,7 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
       "integrity": "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -1360,6 +1359,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/babel__core": {
@@ -1992,6 +1992,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/body-parser/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/body-parser/node_modules/http-errors": {
@@ -2674,15 +2683,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/detect-browser": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
@@ -3154,46 +3154,6 @@
         "express": ">= 4.11"
       }
     },
-    "node_modules/express-session": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
-      "integrity": "sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "0.7.2",
-        "cookie-signature": "1.0.7",
-        "debug": "2.6.9",
-        "depd": "~2.0.0",
-        "on-headers": "~1.1.0",
-        "parseurl": "~1.3.3",
-        "safe-buffer": "5.2.1",
-        "uid-safe": "~2.1.5"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/express-session/node_modules/cookie-signature": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
-      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
-      "license": "MIT"
-    },
-    "node_modules/express-session/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/express-session/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
     "node_modules/express-validator": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
@@ -3214,6 +3174,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/express/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/express/node_modules/http-errors": {
@@ -3305,12 +3274,14 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/file-type": {
       "version": "21.0.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.0.0.tgz",
       "integrity": "sha512-ek5xNX2YBYlXhiUXui3D/BXa3LdqPmoLJ7rqEx2bKJ7EAUEfmXgW0Das7Dc6Nr9MvqaOnIqiPV0mZk/r/UpNAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tokenizer/inflate": "^0.2.7",
@@ -5568,17 +5539,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/lusca": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/lusca/-/lusca-1.7.0.tgz",
-      "integrity": "sha512-msnrplCfY7zaqlZBDEloCIKld+RUeMZVeWzSPaGUKeRXFlruNSdKg2XxCyR+zj6BqzcXhXlRnvcvx6rAGgsvMA==",
-      "dependencies": {
-        "tsscmp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -6019,15 +5979,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/on-headers": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
-      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -6429,15 +6380,6 @@
         "inherits": "~2.0.3"
       }
     },
-    "node_modules/random-bytes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
-      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -6458,6 +6400,15 @@
         "iconv-lite": "0.6.3",
         "unpipe": "1.0.0"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -6804,6 +6755,15 @@
         "node": ">= 18"
       }
     },
+    "node_modules/router/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -6914,6 +6874,15 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/send/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/send/node_modules/http-errors": {
@@ -7448,6 +7417,7 @@
       "version": "10.3.4",
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
       "integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tokenizer/token": "^0.3.0"
@@ -7596,6 +7566,7 @@
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.0.4.tgz",
       "integrity": "sha512-MD9MjpVNhVyH4fyd5rKphjvt/1qj+PtQUz65aFqAZA6XniWAuSFRjLk3e2VALEFlh9OwBpXUN7rfeqSnT/Fmkw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
@@ -7647,15 +7618,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/tsscmp": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
-      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.x"
-      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -7807,22 +7769,11 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/uid-safe": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
-      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
-      "license": "MIT",
-      "dependencies": {
-        "random-bytes": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/uint8array-extras": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.4.0.tgz",
       "integrity": "sha512-ZPtzy0hu4cZjv3z5NW9gfKnNLjoz4y6uv4HlelAjDK7sY/xOkKZv9xK/WQpcsBB3jEybChz9DPC2U/+cusjJVQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/tests/cli_test.sh
+++ b/tests/cli_test.sh
@@ -7,7 +7,7 @@ set -e
 
 # --- Test Setup ---
 CLI_PATH="server/cli.js"
-DB_PATH="server/test-db.json"
+export DB_PATH="server/test-db.json"
 TEST_USER="clitestuser"
 TEST_PASS="password123"
 
@@ -17,18 +17,11 @@ if [ ! -f "$CLI_PATH" ]; then
     exit 1
 fi
 
-# Point the CLI to our test database by temporarily renaming it.
-# This is a simple way to isolate the test environment.
-mv server/db.json "$DB_PATH" 2>/dev/null || true # Ignore error if it doesn't exist
-
-echo "--- Running CLI Tests ---"
-
 # --- Helper Functions ---
 cleanup() {
     echo "--- Cleaning up ---"
-    # Restore the original database and remove the test one.
-    rm "$DB_PATH"
-    mv "$DB_PATH" server/db.json 2>/dev/null || true
+    # Remove the test database, leaving the production db untouched.
+    rm -f "$DB_PATH"
 }
 
 # Register the cleanup function to be called on script exit.


### PR DESCRIPTION
The test script `tests/cli_test.sh` was incorrectly manipulating the production `db.json` file. It would rename the production database to `test-db.json`, run tests against a newly created `db.json`, and then delete the original `test-db.json` during cleanup. This resulted in the loss of production data.

This commit introduces the following changes to fix the issue:

- `server/cli.js` is updated to accept a `DB_PATH` environment variable to specify the database file path. It defaults to `server/db.json` if the variable is not set.

- `tests/cli_test.sh` is updated to use the `DB_PATH` environment variable to point to a dedicated test database, `server/test-db.json`. The test script no longer renames or otherwise interferes with the production database.

- `server/env.example` is updated to include the new `DB_PATH` variable.