### PR TITLE
feat(printshop): Add printing marks to nested SVG

### DIFF
--- a/printshop.html
+++ b/printshop.html
@@ -121,6 +121,10 @@
                         <label for="spacingInput" class="mr-2">Spacing:</label>
                         <input type="number" id="spacingInput" value="10" class="w-20 p-1 border rounded-md">
                     </div>
+                    <div class="mt-4 flex items-center">
+                        <input type="checkbox" id="addPrintingMarks" class="mr-2">
+                        <label for="addPrintingMarks">Add Printing Marks</label>
+                    </div>
                     <div class="mt-4 border-t pt-4">
                         <h3 class="text-lg font-bold mb-2">Media Margins (px)</h3>
                         <div class="grid grid-cols-2 gap-2">

--- a/src/printshop.js
+++ b/src/printshop.js
@@ -566,9 +566,15 @@ async function handleNesting() {
         const nest = new SVGNest(null, svgs, options); // Pass null for binElement
         nest.setBinPolygon(complexBinPolygon); // Use the new method
 
-        const resultSvg = nest.start();
+        let resultSvg = nest.start();
 
-        // 4. Display result
+        // 4. Add printing marks if requested
+        const addPrintingMarksCheckbox = document.getElementById('addPrintingMarks');
+        if (addPrintingMarksCheckbox && addPrintingMarksCheckbox.checked) {
+            resultSvg = addPrintingMarksToSVG(resultSvg);
+        }
+
+        // 5. Display result
         ui.nestedSvgContainer.innerHTML = resultSvg;
         window.nestedSvg = resultSvg;
         showSuccessToast('Nesting complete.');
@@ -616,6 +622,64 @@ function handleDownloadCutFile() {
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
+}
+
+function addPrintingMarksToSVG(svgString) {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(svgString, "image/svg+xml");
+    const svg = doc.documentElement;
+
+    const width = parseFloat(svg.getAttribute('width'));
+    const height = parseFloat(svg.getAttribute('height'));
+    const markLength = 20; // Length of the crop mark lines
+    const markOffset = 10; // Distance from the edge
+
+    const marksGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    marksGroup.setAttribute('stroke', '#000000');
+    marksGroup.setAttribute('stroke-width', '1');
+
+    // Top-left
+    let line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    line.setAttribute('x1', 0); line.setAttribute('y1', -markOffset);
+    line.setAttribute('x2', 0); line.setAttribute('y2', markLength);
+    marksGroup.appendChild(line);
+    line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    line.setAttribute('x1', -markOffset); line.setAttribute('y1', 0);
+    line.setAttribute('x2', markLength); line.setAttribute('y2', 0);
+    marksGroup.appendChild(line);
+
+    // Top-right
+    line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    line.setAttribute('x1', width); line.setAttribute('y1', -markOffset);
+    line.setAttribute('x2', width); line.setAttribute('y2', markLength);
+    marksGroup.appendChild(line);
+    line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    line.setAttribute('x1', width - markLength); line.setAttribute('y1', 0);
+    line.setAttribute('x2', width + markOffset); line.setAttribute('y2', 0);
+    marksGroup.appendChild(line);
+
+    // Bottom-left
+    line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    line.setAttribute('x1', 0); line.setAttribute('y1', height - markLength);
+    line.setAttribute('x2', 0); line.setAttribute('y2', height + markOffset);
+    marksGroup.appendChild(line);
+    line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    line.setAttribute('x1', -markOffset); line.setAttribute('y1', height);
+    line.setAttribute('x2', markLength); line.setAttribute('y2', height);
+    marksGroup.appendChild(line);
+
+    // Bottom-right
+    line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    line.setAttribute('x1', width); line.setAttribute('y1', height - markLength);
+    line.setAttribute('x2', width); line.setAttribute('y2', height + markOffset);
+    marksGroup.appendChild(line);
+    line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    line.setAttribute('x1', width - markLength); line.setAttribute('y1', height);
+    line.setAttribute('x2', width + markOffset); line.setAttribute('y2', height);
+    marksGroup.appendChild(line);
+
+    svg.appendChild(marksGroup);
+    return new XMLSerializer().serializeToString(doc);
 }
 
 function handleExportPdf() {


### PR DESCRIPTION
This change implements the 'Printing Marks' feature from the to-do list.

A checkbox has been added to the Print Shop page to allow the user to add printing marks (crop marks) to the nested SVG print sheet.

When the 'Nest Stickers' button is clicked with this option enabled, a new function `addPrintingMarksToSVG` is called. This function parses the generated SVG, calculates the dimensions, and adds line elements at the four corners to serve as crop marks for production.