### PR TITLE
fix(printshop): Simplify and fix PDF export logic

### DIFF
--- a/src/printshop.js
+++ b/src/printshop.js
@@ -689,18 +689,20 @@ function handleExportPdf() {
     }
 
     try {
-        const doc = new jsPDF({
-            unit: 'px',
-            format: 'a4'
-        });
-
         const svgElement = new DOMParser().parseFromString(window.nestedSvg, "image/svg+xml").documentElement;
-
         const width = parseFloat(svgElement.getAttribute('width'));
         const height = parseFloat(svgElement.getAttribute('height'));
 
-        doc.deletePage(1);
-        doc.addPage([width, height]);
+        if (isNaN(width) || isNaN(height) || width <= 0 || height <= 0) {
+            showErrorToast('Invalid SVG dimensions for PDF export.');
+            return;
+        }
+
+        // Create the PDF with the correct dimensions from the start.
+        const doc = new jsPDF({
+            unit: 'px',
+            format: [width, height]
+        });
 
         SVGtoPDF(doc, svgElement, 0, 0);
 


### PR DESCRIPTION
This change simplifies and fixes the PDF export functionality on the Print Shop page.

The previous implementation used a convoluted method of creating an A4-sized PDF and then replacing the page with a new one sized to the SVG. This was prone to errors and has been simplified.

The new implementation creates the jsPDF document with the correct dimensions from the start, based on the width and height of the nested SVG. This is a more direct and robust approach. It also adds a check for valid SVG dimensions before attempting to create the PDF.