### PR TITLE
feat(orders): Add shipment tracking and auto-delivery status

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "vite",
     "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
+    "test:server": "cd server && npm test",
     "test:e2e": "playwright test",
     "start-mock-server": "json-server --watch db.json --port 3001",
     "styles": "npx tailwindcss build styles.css -o output.css",

--- a/server/package.json
+++ b/server/package.json
@@ -35,7 +35,8 @@
     "nodemailer": "^6.9.14",
     "square": "^43.0.1",
     "svg-parser": "^2.0.4",
-    "tiny-csrf": "1.1.6"
+    "tiny-csrf": "1.1.6",
+    "delivery-tracker": "^2.7.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/server/tracker.js
+++ b/server/tracker.js
@@ -1,0 +1,48 @@
+import tracker from 'delivery-tracker';
+
+let db;
+
+function initializeTracker(database) {
+    db = database;
+    // Check for updates every 5 minutes
+    setInterval(updateTrackingData, 5 * 60 * 1000);
+    console.log('[TRACKER] Shipment tracker initialized.');
+}
+
+async function updateTrackingData() {
+    if (!db) return;
+
+    const shippedOrders = db.data.orders.filter(o => o.status === 'SHIPPED' && o.trackingNumber && o.courier);
+
+    if (shippedOrders.length === 0) {
+        return;
+    }
+
+    console.log(`[TRACKER] Checking status for ${shippedOrders.length} shipped orders...`);
+
+    for (const order of shippedOrders) {
+        try {
+            const courier = tracker.courier(order.courier);
+            courier.trace(order.trackingNumber, (err, result) => {
+                if (err) {
+                    console.error(`[TRACKER] Error tracking order ${order.orderId}:`, err);
+                    return;
+                }
+
+                if (result.status === 'Delivered') {
+                    console.log(`[TRACKER] Order ${order.orderId} has been delivered. Updating status.`);
+                    const orderToUpdate = db.data.orders.find(o => o.orderId === order.orderId);
+                    if (orderToUpdate) {
+                        orderToUpdate.status = 'DELIVERED';
+                        orderToUpdate.lastUpdatedAt = new Date().toISOString();
+                        db.write();
+                    }
+                }
+            });
+        } catch (error) {
+            console.error(`[TRACKER] Failed to track order ${order.orderId}:`, error);
+        }
+    }
+}
+
+export { initializeTracker };


### PR DESCRIPTION
This change implements the 'Shipment Tracking' feature from the to-do list.

- Adds a new UI in the Print Shop page for admins to add a tracking number and select a courier for shipped orders.
- Creates a new server endpoint (`/api/orders/:orderId/tracking`) to save this information to the database.
- Implements a new background tracking service (`server/tracker.js`) that uses the `delivery-tracker` library.
- This service periodically checks for status updates on all shipped orders with tracking numbers.
- When a package is marked as 'Delivered' by the courier, the service automatically updates the order's status in the database to 'DELIVERED'.