### PR TITLE
Refactor email to support SMTP and add integration testing

### DIFF
--- a/docs/digitalocean-cloud-config.yml
+++ b/docs/digitalocean-cloud-config.yml
@@ -178,6 +178,16 @@ write_files:
       TELEGRAM_BOT_TOKEN=YOUR_TELEGRAM_BOT_TOKEN
       TELEGRAM_CHANNEL_ID=YOUR_TELEGRAM_CHANNEL_ID
 
+      # Optional: SMTP Configuration (for self-hosted email)
+      # If these are not set, the server will default to using the Google API.
+      SMTP_HOST=YOUR_SMTP_HOST
+      SMTP_PORT=YOUR_SMTP_PORT
+      SMTP_USER=YOUR_SMTP_USER
+      SMTP_PASS=YOUR_SMTP_PASS
+      SMTP_SECURE=YOUR_SMTP_SECURE # true or false
+      SMTP_FROM=YOUR_SMTP_FROM
+      SMTP_REJECT_UNAUTHORIZED=YOUR_SMTP_REJECT_UNAUTHORIZED # true or false
+
 # 5. Post-setup commands
 # These commands are executed after the server is provisioned.
 runcmd:

--- a/tests/email_integration.test.js
+++ b/tests/email_integration.test.js
@@ -5,8 +5,12 @@ describe('Email Integration Test (SMTP)', () => {
   let server;
   let port;
   let receivedEmails = [];
+  let originalEnv;
 
   beforeAll((done) => {
+    // Backup original environment variables
+    originalEnv = { ...process.env };
+
     // Start a local SMTP server on a random port
     server = new SMTPServer({
       authOptional: true, // We don't need auth for this test sink
@@ -39,11 +43,8 @@ describe('Email Integration Test (SMTP)', () => {
   });
 
   afterAll((done) => {
-    // Cleanup
-    delete process.env.SMTP_HOST;
-    delete process.env.SMTP_PORT;
-    delete process.env.SMTP_SECURE;
-    delete process.env.SMTP_REJECT_UNAUTHORIZED;
+    // Restore original environment variables
+    process.env = originalEnv;
     server.close(done);
   });
 


### PR DESCRIPTION
- Refactored `server/email.js` to support sending emails via SMTP using `nodemailer` when `SMTP_HOST` is configured, with a fallback to Gmail API.
- Added `tests/email_integration.test.js` to verify SMTP email sending using a local `smtp-server` sink, implementing "better testing" practices.
- Fixed duplicate `FINAL_STATUSES` export in `server/server.js`.
- Added `smtp-server` to dev dependencies.
- Updated `scripts/deploy-digitalocean.sh` and `docs/digitalocean-cloud-config.yml` to support interactive SMTP configuration during deployment.
- Improved test isolation by restoring `process.env` in the new integration test.
- Implemented character escaping in the deployment script to safely handle special characters in secrets.