### PR TITLE
Support basic SVG shapes in server-side perimeter calculation

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -85,6 +85,7 @@ This document tracks the features and bug fixes that need to be implemented for 
     - [x] Move the pricing model to be based on the square inch bounding box of the sticker.
     - [x] Adjust the price based on the complexity or length of the generated/provided cut path.
     - [x] **Improve Server-Side Perimeter Calculation:** Replace the simplified regex-based perimeter calculation in `server/pricing.js` with `svg-path-properties` to accurately handle curves and complex paths.
+    - [x] **Support Basic SVG Shapes:** Extend server-side perimeter calculation to support `rect`, `circle`, `ellipse`, `polygon`, and `polyline` elements.
 - [x] **Visual Bounding Box:**
     - [x] Allow the customer to see the calculated bounding box when they scale their uploaded image.
     - [x] **Bug:** Bounding box is not visible.

--- a/server/tests/pricing_shapes.test.js
+++ b/server/tests/pricing_shapes.test.js
@@ -1,0 +1,66 @@
+
+import { getDesignDimensions } from '../pricing.js';
+import fs from 'fs';
+import path from 'path';
+
+const testSvgPath = path.join(process.cwd(), 'test_rect.svg');
+
+describe('Server Pricing - Basic Shapes', () => {
+    const rectSvgPath = path.join(process.cwd(), 'test_rect.svg');
+    const circleSvgPath = path.join(process.cwd(), 'test_circle.svg');
+    const polygonSvgPath = path.join(process.cwd(), 'test_polygon.svg');
+
+    beforeAll(() => {
+        // Rect: 80x80 -> P=320
+        fs.writeFileSync(rectSvgPath, `<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+            <rect x="10" y="10" width="80" height="80" />
+        </svg>`);
+
+        // Circle: r=50 -> P = 2*PI*50 = 314.159...
+        fs.writeFileSync(circleSvgPath, `<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="50" cy="50" r="50" />
+        </svg>`);
+
+        // Polygon: Triangle (0,0) (30,0) (0,40)
+        // Sides: 30, 40, 50 (3-4-5 triangle). P = 120
+        fs.writeFileSync(polygonSvgPath, `<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+            <polygon points="0,0 30,0 0,40" />
+        </svg>`);
+    });
+
+    afterAll(() => {
+        if (fs.existsSync(rectSvgPath)) fs.unlinkSync(rectSvgPath);
+        if (fs.existsSync(circleSvgPath)) fs.unlinkSync(circleSvgPath);
+        if (fs.existsSync(polygonSvgPath)) fs.unlinkSync(polygonSvgPath);
+    });
+
+    // Helper to calculate perimeter from cutline
+    function getCutlinePerimeter(cutline) {
+        const poly = cutline[0];
+        let calculatedPerimeter = 0;
+        for (let i = 0; i < poly.length; i++) {
+            const p1 = poly[i];
+            const p2 = poly[(i + 1) % poly.length];
+            calculatedPerimeter += Math.sqrt(Math.pow(p2.x - p1.x, 2) + Math.pow(p2.y - p1.y, 2));
+        }
+        return calculatedPerimeter;
+    }
+
+    it('should calculate perimeter for rect elements', async () => {
+        const dimensions = await getDesignDimensions(rectSvgPath);
+        const p = getCutlinePerimeter(dimensions.cutline);
+        expect(p).toBeCloseTo(320, 1);
+    });
+
+    it('should calculate perimeter for circle elements', async () => {
+        const dimensions = await getDesignDimensions(circleSvgPath);
+        const p = getCutlinePerimeter(dimensions.cutline);
+        expect(p).toBeCloseTo(2 * Math.PI * 50, 1);
+    });
+
+    it('should calculate perimeter for polygon elements', async () => {
+        const dimensions = await getDesignDimensions(polygonSvgPath);
+        const p = getCutlinePerimeter(dimensions.cutline);
+        expect(p).toBeCloseTo(120, 1);
+    });
+});


### PR DESCRIPTION
Enhanced `server/pricing.js` to correctly calculate the perimeter for `rect`, `circle`, `ellipse`, `polygon`, and `polyline` elements in uploaded SVGs. Previously, only `path` elements were considered, leading to incorrect price calculations (zero perimeter) for simple shape-based SVGs.

Added `server/tests/pricing_shapes.test.js` to verify the fix and prevent regressions.
Updated `ToDo.md` to reflect the completed task.

---
*PR created automatically by Jules for task [9455337976643734470](https://jules.google.com/task/9455337976643734470) started by @LokiMetaSmith*