### PR TITLE
🛡️ Sentinel: [medium] Add Permissions-Policy and Referrer-Policy headers

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -536,6 +536,15 @@ async function startServer(
         next();
     });
 
+    // SECURITY: Add additional security headers not covered by lusca
+    app.use((req, res, next) => {
+        // Permissions-Policy: Disables powerful features that the app doesn't need
+        res.setHeader('Permissions-Policy', 'geolocation=(), microphone=(), camera=()');
+        // Referrer-Policy: Controls how much referrer information is sent to other sites
+        res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+        next();
+    });
+
     app.use(lusca({
         csrf: true,
         xframe: 'SAMEORIGIN',

--- a/server/tests/security_headers.test.js
+++ b/server/tests/security_headers.test.js
@@ -1,0 +1,67 @@
+import { describe, beforeAll, afterAll, it, expect, jest } from '@jest/globals';
+import request from 'supertest';
+import { startServer } from '../server.js';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+describe('Security: HTTP Headers', () => {
+  let app;
+  let db;
+  let serverInstance;
+  let timers;
+  let bot;
+  let mockSendEmail;
+  const testDbPath = path.join(__dirname, 'test-db-headers.json');
+
+  const mockSquareClient = {
+    locations: {},
+    payments: {
+      create: jest.fn().mockResolvedValue({
+        payment: { id: 'mock_payment_id', orderId: 'mock_square_order_id' }
+      })
+    }
+  };
+
+  beforeAll(async () => {
+    // Mock DB
+    const data = { orders: {}, users: {}, credentials: {}, config: {}, products: {} };
+    db = {
+      data: data,
+      write: async () => { },
+      read: async () => { }
+    };
+
+    mockSendEmail = jest.fn();
+
+    // Pass mock Square client
+    const server = await startServer(db, null, mockSendEmail, testDbPath, mockSquareClient);
+    app = server.app;
+    timers = server.timers;
+    bot = server.bot;
+    serverInstance = app.listen();
+  });
+
+  afterAll(async () => {
+    if (bot) await bot.stop('test');
+    if (timers) timers.forEach(timer => clearInterval(timer));
+    await new Promise(resolve => serverInstance.close(resolve));
+  });
+
+  it('should have correct security headers on /api/ping', async () => {
+    const res = await request(app).get('/api/ping');
+
+    expect(res.statusCode).toEqual(200);
+
+    // X-Content-Type-Options should be set by lusca
+    expect(res.headers['x-content-type-options']).toEqual('nosniff');
+
+    // Permissions-Policy (Feature-Policy)
+    expect(res.headers['permissions-policy']).toEqual('geolocation=(), microphone=(), camera=()');
+
+    // Referrer-Policy
+    expect(res.headers['referrer-policy']).toEqual('strict-origin-when-cross-origin');
+  });
+});


### PR DESCRIPTION
🛡️ Sentinel: [medium] Add Permissions-Policy and Referrer-Policy headers

**Severity:** MEDIUM (Enhancement)
**Vulnerability:** Missing modern security headers allowing potential feature abuse and referrer leakage.
**Impact:** 
- Without `Permissions-Policy`, compromised frontend code could potentially access sensitive APIs like geolocation or camera/mic if the user approves.
- Without `Referrer-Policy`, sensitive URLs (e.g., containing tokens or IDs) might be leaked to third-party sites via the Referer header.
**Fix:** Added middleware to explicitly set strict policies for these headers.
**Verification:**
- Run `npm test server/tests/security_headers.test.js` to verify the headers are set on response.
- Full server test suite passed.

---
*PR created automatically by Jules for task [4029616665419480123](https://jules.google.com/task/4029616665419480123) started by @LokiMetaSmith*