### PR TITLE
🎨 Palette: Add unit price display to calculator

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -570,10 +570,19 @@ function calculateAndUpdatePrice() {
     markupHtml = `<span class="text-xs text-green-600 block">Includes Creator Support: ${formatPrice(totalMarkup)}</span>`;
   }
 
+  const unitPriceCents = quantity > 0 ? currentOrderAmountCents / quantity : 0;
+  const unitPriceDisplay =
+    quantity > 1 && unitPriceCents > 0
+      ? `<span class="text-sm text-gray-500 font-medium ml-2">(${formatPrice(unitPriceCents)} each)</span>`
+      : "";
+
   calculatedPriceDisplay.innerHTML = `
-        <span class="font-bold text-lg">${formatPrice(currentOrderAmountCents)}</span>
+        <div class="flex items-baseline">
+            <span class="font-bold text-lg">${formatPrice(currentOrderAmountCents)}</span>
+            ${unitPriceDisplay}
+        </div>
         ${markupHtml}
-        <span class="text-sm text-gray-600 block">
+        <span class="text-sm text-gray-600 block mt-1">
             Size: ${width.toFixed(1)}${unit} x ${height.toFixed(1)}${unit}
         </span>
         <span class="text-xs text-gray-500 block">


### PR DESCRIPTION
Added a micro-UX improvement to the pricing calculator. When a user selects a quantity greater than 1, the interface now displays the calculated price per unit alongside the total estimated price. This helps users understand the value of bulk ordering and provides clearer pricing information.

Changes:
- Modified `calculateAndUpdatePrice` in `src/index.js` to calculate and format unit price.
- Updated `calculatedPriceDisplay.innerHTML` to include the unit price in a flex container.
- Added logic to handle edge cases (quantity <= 1 or invalid price).

---
*PR created automatically by Jules for task [9363987947749121374](https://jules.google.com/task/9363987947749121374) started by @LokiMetaSmith*