### PR TITLE
Add tests for Telegram bot commands

### DIFF
--- a/server/bot.js
+++ b/server/bot.js
@@ -4,15 +4,138 @@ import { getSecret } from './secretManager.js';
 import { getOrderStatusKeyboard } from './telegramHelpers.js';
 
 let bot;
-let db;
 
-function initializeBot(database) {
-  db = database;
+function initializeBot(db) {
   const token = getSecret('TELEGRAM_BOT_TOKEN');
 
   if (token) {
     const isTestEnv = process.env.NODE_ENV === 'test';
     bot = new Telegraf(token);
+
+    const listOrdersByStatus = (ctx, statuses, title) => {
+      try {
+        const orders = Object.values(db.data.orders).filter(o => statuses.includes(o.status));
+
+        if (orders.length === 0) {
+          ctx.reply(`No orders with status: ${statuses.join(', ')}`)
+            .catch(err => console.error('[TELEGRAM] Error sending message:', err));
+          return;
+        }
+
+        // SECURITY: Use HTML mode for safer rendering.
+        // Note: input variables like billingContact are expected to be HTML-escaped by server.js (using escapeHtml)
+        // before being stored in the database. This prevents HTML injection.
+        // We switched from Markdown because Markdown characters in user input were not escaped, causing injection.
+        let list = `<b>${title}:</b>\n\n`;
+        orders.forEach(order => {
+          list += `• <b>Order ID:</b> <code>${order.orderId}</code>\n`;
+          list += `  <b>Status:</b> ${order.status}\n`;
+          list += `  <b>Customer:</b> ${order.billingContact.givenName} ${order.billingContact.familyName}\n\n`;
+        });
+
+        ctx.replyWithHTML(list)
+           .catch(err => console.error('[TELEGRAM] Error sending message:', err));
+      } catch (error) {
+        console.error('[TELEGRAM] A critical error occurred in listOrdersByStatus:', error);
+        ctx.reply('Sorry, an internal error occurred while fetching the order list.')
+           .catch(err => console.error('[TELEGRAM] Error sending critical error message:', err));
+      }
+    };
+
+    bot.command('jobs', (ctx) => listOrdersByStatus(ctx, ['NEW', 'ACCEPTED', 'PRINTING'], 'All Active Jobs'));
+    bot.command('new_orders', (ctx) => listOrdersByStatus(ctx, ['NEW'], 'New Orders'));
+    bot.command('in_process_orders', (ctx) => listOrdersByStatus(ctx, ['ACCEPTED', 'PRINTING'], 'In Process Orders'));
+    bot.command('shipped_orders', (ctx) => listOrdersByStatus(ctx, ['SHIPPED'], 'Shipped Orders'));
+    bot.command('canceled_orders', (ctx) => listOrdersByStatus(ctx, ['CANCELED'], 'Canceled Orders'));
+    bot.command('delivered_orders', (ctx) => listOrdersByStatus(ctx, ['DELIVERED'], 'Delivered Orders'));
+    bot.command('completed_orders', (ctx) => listOrdersByStatus(ctx, ['COMPLETED'], 'Completed Orders'));
+
+    // Listen for replies to add notes to orders
+    bot.on(message('text'), async (ctx) => {
+      if (ctx.message.reply_to_message) {
+        const originalMessageId = ctx.message.reply_to_message.message_id;
+        const order = Object.values(db.data.orders).find(o => o.telegramMessageId === originalMessageId || o.telegramPhotoMessageId === originalMessageId);
+
+        if (order) {
+          if (!order.notes) {
+            order.notes = [];
+          }
+          const note = {
+            text: ctx.message.text,
+            from: ctx.from.username || `${ctx.from.first_name} ${ctx.from.last_name || ''}`.trim(),
+            date: new Date(ctx.message.date * 1000).toISOString(),
+          };
+          order.notes.push(note);
+          await db.write();
+
+          ctx.reply("Note added successfully!", {
+            reply_to_message_id: ctx.message.message_id
+          }).catch(err => console.error('[TELEGRAM] Error sending confirmation message:', err));
+        }
+      }
+    });
+
+    bot.on('callback_query', async (ctx) => {
+      const [action, orderId] = ctx.callbackQuery.data.split('_');
+      const order = db.data.orders[orderId];
+
+      if (order) {
+        let newStatus;
+        switch (action) {
+          case 'accept':
+            newStatus = 'ACCEPTED';
+            break;
+          case 'print':
+            newStatus = 'PRINTING';
+            break;
+          case 'ship':
+            newStatus = 'SHIPPED';
+            break;
+          case 'deliver':
+            newStatus = 'DELIVERED';
+            break;
+          case 'complete':
+              newStatus = 'COMPLETED';
+              break;
+          case 'cancel':
+            newStatus = 'CANCELED';
+            break;
+        }
+
+        if (newStatus) {
+          order.status = newStatus;
+          await db.write();
+
+          const acceptedOrLater = ['ACCEPTED', 'PRINTING', 'SHIPPED', 'DELIVERED', 'COMPLETED'];
+          const printingOrLater = ['PRINTING', 'SHIPPED', 'DELIVERED', 'COMPLETED'];
+          const shippedOrLater = ['SHIPPED', 'DELIVERED', 'COMPLETED'];
+          const deliveredOrLater = ['DELIVERED', 'COMPLETED'];
+          const completedOrLater = ['COMPLETED'];
+
+          const statusChecklist = `
+✅ New
+${acceptedOrLater.includes(newStatus) ? '✅' : '⬜️'} Accepted
+${printingOrLater.includes(newStatus) ? '✅' : '⬜️'} Printing
+${shippedOrLater.includes(newStatus) ? '✅' : '⬜️'} Shipped
+${deliveredOrLater.includes(newStatus) ? '✅' : '⬜️'} Delivered
+${completedOrLater.includes(newStatus) ? '✅' : '⬜️'} Completed
+            `;
+
+          const message = `
+Order: ${order.orderId}
+Customer: ${order.billingContact.givenName} ${order.billingContact.familyName}
+Email: ${order.billingContact.email}
+Quantity: ${order.orderDetails.quantity}
+Amount: $${(order.amount / 100).toFixed(2)}
+
+${statusChecklist}
+            `;
+          const keyboard = getOrderStatusKeyboard(order);
+          ctx.editMessageText(message, { reply_markup: keyboard });
+        }
+      }
+      ctx.answerCbQuery();
+    });
 
     if (!isTestEnv) {
       const commands = [
@@ -25,143 +148,20 @@ function initializeBot(database) {
         { command: 'completed_orders', description: 'Lists all COMPLETED orders' },
       ];
       bot.telegram.setMyCommands(commands);
-
-      const listOrdersByStatus = (ctx, statuses, title) => {
-        try {
-          const orders = Object.values(db.data.orders).filter(o => statuses.includes(o.status));
-
-          if (orders.length === 0) {
-            ctx.reply(`No orders with status: ${statuses.join(', ')}`)
-              .catch(err => console.error('[TELEGRAM] Error sending message:', err));
-            return;
-          }
-
-          // SECURITY: Use HTML mode for safer rendering.
-          // Note: input variables like billingContact are expected to be HTML-escaped by server.js (using escapeHtml)
-          // before being stored in the database. This prevents HTML injection.
-          // We switched from Markdown because Markdown characters in user input were not escaped, causing injection.
-          let list = `<b>${title}:</b>\n\n`;
-          orders.forEach(order => {
-            list += `• <b>Order ID:</b> <code>${order.orderId}</code>\n`;
-            list += `  <b>Status:</b> ${order.status}\n`;
-            list += `  <b>Customer:</b> ${order.billingContact.givenName} ${order.billingContact.familyName}\n\n`;
-          });
-
-          ctx.replyWithHTML(list)
-             .catch(err => console.error('[TELEGRAM] Error sending message:', err));
-        } catch (error) {
-          console.error('[TELEGRAM] A critical error occurred in listOrdersByStatus:', error);
-          ctx.reply('Sorry, an internal error occurred while fetching the order list.')
-             .catch(err => console.error('[TELEGRAM] Error sending critical error message:', err));
-        }
-      };
-
-      bot.command('jobs', (ctx) => listOrdersByStatus(ctx, ['NEW', 'ACCEPTED', 'PRINTING'], 'All Active Jobs'));
-      bot.command('new_orders', (ctx) => listOrdersByStatus(ctx, ['NEW'], 'New Orders'));
-      bot.command('in_process_orders', (ctx) => listOrdersByStatus(ctx, ['ACCEPTED', 'PRINTING'], 'In Process Orders'));
-      bot.command('shipped_orders', (ctx) => listOrdersByStatus(ctx, ['SHIPPED'], 'Shipped Orders'));
-      bot.command('canceled_orders', (ctx) => listOrdersByStatus(ctx, ['CANCELED'], 'Canceled Orders'));
-      bot.command('delivered_orders', (ctx) => listOrdersByStatus(ctx, ['DELIVERED'], 'Delivered Orders'));
-      bot.command('completed_orders', (ctx) => listOrdersByStatus(ctx, ['COMPLETED'], 'Completed Orders'));
-
-      // Listen for replies to add notes to orders
-      bot.on(message('text'), async (ctx) => {
-        if (ctx.message.reply_to_message) {
-          const originalMessageId = ctx.message.reply_to_message.message_id;
-          const order = Object.values(db.data.orders).find(o => o.telegramMessageId === originalMessageId || o.telegramPhotoMessageId === originalMessageId);
-
-          if (order) {
-            if (!order.notes) {
-              order.notes = [];
-            }
-            const note = {
-              text: ctx.message.text,
-              from: ctx.from.username || `${ctx.from.first_name} ${ctx.from.last_name || ''}`.trim(),
-              date: new Date(ctx.message.date * 1000).toISOString(),
-            };
-            order.notes.push(note);
-            await db.write();
-
-            ctx.reply("Note added successfully!", {
-              reply_to_message_id: ctx.message.message_id
-            }).catch(err => console.error('[TELEGRAM] Error sending confirmation message:', err));
-          }
-        }
-      });
-
-      bot.on('callback_query', async (ctx) => {
-        const [action, orderId] = ctx.callbackQuery.data.split('_');
-        const order = db.data.orders[orderId];
-
-        if (order) {
-          let newStatus;
-          switch (action) {
-            case 'accept':
-              newStatus = 'ACCEPTED';
-              break;
-            case 'print':
-              newStatus = 'PRINTING';
-              break;
-            case 'ship':
-              newStatus = 'SHIPPED';
-              break;
-            case 'deliver':
-              newStatus = 'DELIVERED';
-              break;
-            case 'complete':
-                newStatus = 'COMPLETED';
-                break;
-            case 'cancel':
-              newStatus = 'CANCELED';
-              break;
-          }
-
-          if (newStatus) {
-            order.status = newStatus;
-            await db.write();
-
-            const acceptedOrLater = ['ACCEPTED', 'PRINTING', 'SHIPPED', 'DELIVERED', 'COMPLETED'];
-            const printingOrLater = ['PRINTING', 'SHIPPED', 'DELIVERED', 'COMPLETED'];
-            const shippedOrLater = ['SHIPPED', 'DELIVERED', 'COMPLETED'];
-            const deliveredOrLater = ['DELIVERED', 'COMPLETED'];
-            const completedOrLater = ['COMPLETED'];
-
-            const statusChecklist = `
-✅ New
-${acceptedOrLater.includes(newStatus) ? '✅' : '⬜️'} Accepted
-${printingOrLater.includes(newStatus) ? '✅' : '⬜️'} Printing
-${shippedOrLater.includes(newStatus) ? '✅' : '⬜️'} Shipped
-${deliveredOrLater.includes(newStatus) ? '✅' : '⬜️'} Delivered
-${completedOrLater.includes(newStatus) ? '✅' : '⬜️'} Completed
-            `;
-
-            const message = `
-Order: ${order.orderId}
-Customer: ${order.billingContact.givenName} ${order.billingContact.familyName}
-Email: ${order.billingContact.email}
-Quantity: ${order.orderDetails.quantity}
-Amount: $${(order.amount / 100).toFixed(2)}
-
-${statusChecklist}
-            `;
-            const keyboard = getOrderStatusKeyboard(order);
-            ctx.editMessageText(message, { reply_markup: keyboard });
-          }
-        }
-        ctx.answerCbQuery();
-      });
-
       bot.launch();
       console.log('[BOT] Telegraf bot launched.');
     } else {
       // In a test environment, we don't launch the bot, but we need to mock the telegram object.
       // Use no-op functions instead of assuming jest.fn() is available, since this code runs in the server process
+      // Create a new object to replace bot.telegram
       bot.telegram = {
         sendMessage: () => Promise.resolve(),
         sendPhoto: () => Promise.resolve(),
         sendDocument: () => Promise.resolve(),
         editMessageText: () => Promise.resolve(),
         deleteMessage: () => Promise.resolve(),
+        setMyCommands: () => Promise.resolve(),
+        getMe: () => Promise.resolve({ id: 123456, is_bot: true, first_name: 'TestBot', username: 'TestBot' }),
       };
     }
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -29,8 +29,17 @@ This directory contains the unit tests for the Print Shop application.
 *   Tests the file upload endpoint:
     *   `/api/upload-design` (Including validation, file type checks, and SVG sanitization)
 
+### `telegram_bot.test.js`
+
+*   Tests the Telegram bot commands and interactions:
+    *   `/jobs`, `/new_orders` and other list commands.
+    *   Callback query handling for order status updates.
+
+### `telegram_stalled_message.test.js`
+
+*   Tests that the "Order Stalled" message is deleted when order status changes.
+
 ## Future Tests
 
 *   Add tests for the encryption/decryption of the client JSON file.
-*   Add tests for the Telegram bot.
 *   Add tests for the `generateCutFile` function.

--- a/tests/telegram_bot.test.js
+++ b/tests/telegram_bot.test.js
@@ -1,0 +1,173 @@
+import { describe, beforeAll, afterAll, it, expect, jest } from '@jest/globals';
+import { initializeBot } from '../server/bot.js';
+import { Context } from 'telegraf';
+import { JSONFilePreset } from 'lowdb/node';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import fs from 'fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+describe('Telegram Bot Commands', () => {
+    let db;
+    let bot;
+    const testDbPath = path.join(__dirname, 'test-db-telegram-bot.json');
+
+    beforeAll(async () => {
+        process.env.TELEGRAM_BOT_TOKEN = 'mock-token';
+        process.env.TELEGRAM_CHANNEL_ID = 'mock-channel';
+        process.env.NODE_ENV = 'test';
+
+        // Setup clean DB
+        if (fs.existsSync(testDbPath)) {
+            fs.unlinkSync(testDbPath);
+        }
+        db = await JSONFilePreset(testDbPath, { orders: {}, users: {}, credentials: {}, config: {} });
+
+        // Seed some data
+        db.data.orders['order-new'] = {
+            orderId: 'order-new',
+            status: 'NEW',
+            amount: 1000,
+            currency: 'USD',
+            billingContact: { givenName: 'John', familyName: 'Doe', email: 'john@example.com' },
+            orderDetails: { quantity: 10 }
+        };
+        db.data.orders['order-printing'] = {
+            orderId: 'order-printing',
+            status: 'PRINTING',
+            amount: 2000,
+            currency: 'USD',
+            billingContact: { givenName: 'Jane', familyName: 'Smith', email: 'jane@example.com' },
+            orderDetails: { quantity: 20 }
+        };
+        await db.write();
+
+        bot = initializeBot(db);
+
+        // Override mocks with jest spies
+        bot.telegram.sendMessage = jest.fn().mockResolvedValue({ message_id: 123 });
+        bot.telegram.editMessageText = jest.fn().mockResolvedValue(true);
+        bot.telegram.answerCbQuery = jest.fn().mockResolvedValue(true);
+    });
+
+    afterAll(() => {
+        if (fs.existsSync(testDbPath)) fs.unlinkSync(testDbPath);
+    });
+
+    it('should handle /jobs command and list active orders', async () => {
+        const update = {
+            update_id: 1,
+            message: {
+                message_id: 1,
+                from: { id: 123, is_bot: false, first_name: 'TestUser' },
+                chat: { id: 123, type: 'private' },
+                date: 1620000000,
+                text: '/jobs',
+                entities: [{ type: 'bot_command', offset: 0, length: 5 }]
+            }
+        };
+
+        const ctx = new Context(update, bot.telegram, bot.botInfo);
+        await bot.middleware()(ctx, () => Promise.resolve());
+
+        expect(bot.telegram.sendMessage).toHaveBeenCalledWith(
+            123, // chat id
+            expect.stringContaining('All Active Jobs'),
+            expect.objectContaining({ parse_mode: 'HTML' })
+        );
+        expect(bot.telegram.sendMessage).toHaveBeenCalledWith(
+            123,
+            expect.stringContaining('order-new'),
+            expect.anything()
+        );
+        expect(bot.telegram.sendMessage).toHaveBeenCalledWith(
+            123,
+            expect.stringContaining('order-printing'),
+            expect.anything()
+        );
+    });
+
+    it('should handle /new_orders command and list only NEW orders', async () => {
+        bot.telegram.sendMessage.mockClear();
+        const update = {
+            update_id: 2,
+            message: {
+                message_id: 2,
+                from: { id: 123, is_bot: false, first_name: 'TestUser' },
+                chat: { id: 123, type: 'private' },
+                date: 1620000000,
+                text: '/new_orders',
+                entities: [{ type: 'bot_command', offset: 0, length: 11 }]
+            }
+        };
+
+        const ctx = new Context(update, bot.telegram, bot.botInfo);
+        await bot.middleware()(ctx, () => Promise.resolve());
+
+        expect(bot.telegram.sendMessage).toHaveBeenCalledWith(
+            123,
+            expect.stringContaining('New Orders'),
+            expect.objectContaining({ parse_mode: 'HTML' })
+        );
+        expect(bot.telegram.sendMessage).toHaveBeenCalledWith(
+            123,
+            expect.stringContaining('order-new'),
+            expect.anything()
+        );
+        expect(bot.telegram.sendMessage).toHaveBeenCalledWith(
+            123,
+            expect.not.stringContaining('order-printing'),
+            expect.anything()
+        );
+    });
+
+    it('should handle callback query to accept order', async () => {
+        const update = {
+            update_id: 3,
+            callback_query: {
+                id: 'cb1',
+                from: { id: 123, is_bot: false, first_name: 'TestUser' },
+                message: { message_id: 999, chat: { id: 123 } },
+                data: 'accept_order-new'
+            }
+        };
+
+        const ctx = new Context(update, bot.telegram, bot.botInfo);
+        await bot.middleware()(ctx, () => Promise.resolve());
+
+        // Verify DB update
+        const order = db.data.orders['order-new'];
+        expect(order.status).toBe('ACCEPTED');
+
+        // Verify message edit
+        expect(bot.telegram.editMessageText).toHaveBeenCalledWith(
+            123,
+            999,
+            undefined, // inline_message_id
+            expect.stringContaining('Accepted'),
+            expect.objectContaining({ reply_markup: expect.anything() })
+        );
+    });
+
+    it('should handle callback query to print order', async () => {
+        const update = {
+            update_id: 4,
+            callback_query: {
+                id: 'cb2',
+                from: { id: 123, is_bot: false, first_name: 'TestUser' },
+                message: { message_id: 999, chat: { id: 123 } },
+                data: 'print_order-new'
+            }
+        };
+
+        const ctx = new Context(update, bot.telegram, bot.botInfo);
+        await bot.middleware()(ctx, () => Promise.resolve());
+
+        const order = db.data.orders['order-new'];
+        expect(order.status).toBe('PRINTING');
+
+        expect(bot.telegram.editMessageText).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Implemented tests for Telegram bot commands as requested. This involved refactoring `server/bot.js` to expose command registration logic to the test environment and removing the global `db` variable to improve code quality and test isolation. A new test suite `tests/telegram_bot.test.js` covers key bot commands and interactions.

---
*PR created automatically by Jules for task [13739312675932616822](https://jules.google.com/task/13739312675932616822) started by @LokiMetaSmith*