### PR TITLE
🎨 Palette: Add text size slider for better control

### DIFF
--- a/index.html
+++ b/index.html
@@ -436,14 +436,25 @@
                   style="font-family: var(--font-baumans)"
                   >Size (px):</label
                 >
-                <input
-                  type="number"
-                  id="textSizeInput"
-                  value="30"
-                  min="8"
-                  max="200"
-                  class="input mt-1 w-full"
-                />
+                <div class="flex items-center gap-2 mt-1">
+                  <input
+                    type="number"
+                    id="textSizeInput"
+                    value="30"
+                    min="8"
+                    max="200"
+                    class="input w-20 text-center"
+                  />
+                  <input
+                    type="range"
+                    id="textSizeSlider"
+                    min="8"
+                    max="200"
+                    value="30"
+                    class="flex-grow cursor-pointer"
+                    aria-label="Text size slider"
+                  />
+                </div>
               </div>
               <div>
                 <label

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,7 @@ let isSepia = false;
 
 let textInput,
   textSizeInput,
+  textSizeSlider,
   textColorInput,
   addTextBtn,
   textFontFamilySelect,
@@ -94,6 +95,7 @@ async function BootStrap() {
 
   textInput = document.getElementById("textInput");
   textSizeInput = document.getElementById("textSizeInput");
+  textSizeSlider = document.getElementById("textSizeSlider");
   textColorInput = document.getElementById("textColorInput");
   addTextBtn = document.getElementById("addTextBtn");
   textFontFamilySelect = document.getElementById("textFontFamily");
@@ -185,6 +187,16 @@ async function BootStrap() {
   }
   if (addTextBtn) {
     addTextBtn.addEventListener("click", handleAddText);
+  }
+
+  // Sync text size slider and input
+  if (textSizeSlider && textSizeInput) {
+    textSizeSlider.addEventListener("input", (e) => {
+      textSizeInput.value = e.target.value;
+    });
+    textSizeInput.addEventListener("input", (e) => {
+      textSizeSlider.value = e.target.value;
+    });
   }
   if (rotateLeftBtnEl)
     rotateLeftBtnEl.addEventListener("click", () =>
@@ -1028,6 +1040,7 @@ function updateEditingButtonsState(disabled) {
     document.getElementById("generateCutlineBtn"),
     textInput,
     textSizeInput,
+    textSizeSlider,
     textColorInput,
     addTextBtn,
     textFontFamilySelect,


### PR DESCRIPTION
**What:** Added a range slider (`input[type="range"]`) next to the "Size (px)" input in the text editing controls.
**Why:** Users often prefer visual sliders for sizing adjustments rather than guessing pixel values. This aligns with the existing Image Size control pattern.
**Accessibility:** The slider is keyboard accessible and has `aria-label="Text size slider"`. It stays synchronized with the number input.
**Verification:** Verified visually with Playwright script (screenshot confirmed) and ensured logic handles synchronization correctly.

---
*PR created automatically by Jules for task [1661349977210451421](https://jules.google.com/task/1661349977210451421) started by @LokiMetaSmith*