### PR TITLE
🎨 Palette: Fix Skip Link accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -23,3 +23,7 @@
 ## 2025-02-24 - Modal Focus Management
 **Learning:** Modals implemented with simple visibility toggles (like `.hidden`) often trap focus or fail to restore it, leaving keyboard users lost.
 **Action:** When opening a modal, save `document.activeElement` and move focus to the modal's first input. When closing, restore focus to the saved element. Always map `Escape` to close.
+
+## 2025-05-21 - Skip Link Targets
+**Learning:** Anchor links (skip links) targeting non-interactive elements (like divs/sections) do not move keyboard focus unless the target has `tabindex="-1"`.
+**Action:** Always add `tabindex="-1"` and `outline-none` (if visual ring is unwanted) to container elements targeted by skip links.

--- a/index.html
+++ b/index.html
@@ -126,7 +126,8 @@
         <!-- Sticker Design and Options Box -->
         <div
           id="sticker-design-box"
-          class="p-6 rounded-lg shadow-md border border-gray-200 bg-gray-50 mb-8"
+          class="p-6 rounded-lg shadow-md border border-gray-200 bg-gray-50 mb-8 outline-none"
+          tabindex="-1"
         >
           <!-- UPLOAD STICKER FILE -->
           <div class="field mb-6">


### PR DESCRIPTION
**What:** Added `tabindex="-1"` and `outline-none` to the `#sticker-design-box` div.
**Why:** The "Skip to Sticker Editor" link was failing to move keyboard focus to the target container because it wasn't focusable. This change ensures keyboard users (and screen readers) are correctly transported to the main content area when using the skip link.
**Accessibility:**
- Ensures `Skip to Sticker Editor` is functional for keyboard navigation.
- Removes the visual outline on the container itself (`outline-none`) to avoid a large box focus ring, while maintaining the functional focus shift.
- Documented the pattern in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [7104817468923733849](https://jules.google.com/task/7104817468923733849) started by @LokiMetaSmith*