### PR TITLE
⚡ Bolt: Optimize rotated polygon bounds calculation

### DIFF
--- a/src/lib/geometryutil.js
+++ b/src/lib/geometryutil.js
@@ -386,6 +386,30 @@ export const GeometryUtil = {
         if (polygon.source) rotated.source = polygon.source;
         return rotated;
     },
+
+    getRotatedPolygonBounds: function(polygon, angle) {
+        if (!polygon || polygon.length === 0) return null;
+        if (Math.abs(angle) < TOL) return this.getPolygonBounds(polygon);
+
+        const angleRad = _degreesToRadians(angle);
+        const cos = Math.cos(angleRad);
+        const sin = Math.sin(angleRad);
+
+        let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+
+        for (let i = 0; i < polygon.length; i++) {
+            const p = polygon[i];
+            const rx = p.x * cos - p.y * sin;
+            const ry = p.x * sin + p.y * cos;
+
+            if (rx < minX) minX = rx;
+            if (rx > maxX) maxX = rx;
+            if (ry < minY) minY = ry;
+            if (ry > maxY) maxY = ry;
+        }
+
+        return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+    },
     
     // ... other methods from original file can be added here ...
 };

--- a/src/lib/placementworker.js
+++ b/src/lib/placementworker.js
@@ -219,8 +219,8 @@ export class PlacementWorker {
 
         placements.forEach(p => {
             const part = this.parts[p.id];
-            const rotatedPart = GeometryUtil.rotatePolygon(part, p.rotation);
-            const bounds = GeometryUtil.getPolygonBounds(rotatedPart);
+            // Bolt Optimization: Use getRotatedPolygonBounds to avoid allocating new polygon points
+            const bounds = GeometryUtil.getRotatedPolygonBounds(part, p.rotation);
 
             const partMinX = p.x + bounds.x;
             const partMinY = p.y + bounds.y;

--- a/src/lib/svgnest.js
+++ b/src/lib/svgnest.js
@@ -27,8 +27,7 @@ export class GeneticAlgorithm {
         for (const part of adam) {
             const valid = [];
             for (const angle of allAngles) {
-                const rotatedPart = GeometryUtil.rotatePolygon(part, angle);
-                const rotatedBounds = GeometryUtil.getPolygonBounds(rotatedPart);
+                const rotatedBounds = GeometryUtil.getRotatedPolygonBounds(part, angle);
                 if (rotatedBounds.width < this.binBounds.width && rotatedBounds.height < this.binBounds.height) {
                     valid.push(angle);
                 }
@@ -253,8 +252,8 @@ export class SvgNest {
             placedGroup.forEach(p => {
                 const originalPart = this.tree.find(part => part.id === p.id);
                 // We need to rotate the polygon to get accurate bounds
-                const rotatedPart = GeometryUtil.rotatePolygon(originalPart, p.rotation);
-                const partBounds = GeometryUtil.getPolygonBounds(rotatedPart);
+                // Bolt Optimization: Use getRotatedPolygonBounds to avoid allocating new polygon points
+                const partBounds = GeometryUtil.getRotatedPolygonBounds(originalPart, p.rotation);
 
                 // Placement x, y corresponds to the origin (0,0) of the part's coordinate system.
                 // We need to add the rotated part's bounds offset (which might be negative) to get the visual edges.

--- a/tests/geometry_util.test.js
+++ b/tests/geometry_util.test.js
@@ -33,3 +33,43 @@ describe('GeometryUtil.rectsIntersect', () => {
         expect(GeometryUtil.rectsIntersect(r1, r2)).toBe(false);
     });
 });
+
+describe('GeometryUtil.getRotatedPolygonBounds', () => {
+    it('should calculate correct bounds for 90 degree rotation', () => {
+        const poly = [{x:0, y:0}, {x:100, y:0}, {x:100, y:50}, {x:0, y:50}];
+        // 100x50 rect.
+        // Rotated 90 degrees around 0,0:
+        // (0,0) -> (0,0)
+        // (100,0) -> (0, 100)
+        // (100,50) -> (-50, 100)
+        // (0,50) -> (-50, 0)
+        // Bounds: x: -50, y: 0, w: 50, h: 100
+
+        const bounds = GeometryUtil.getRotatedPolygonBounds(poly, 90);
+
+        expect(bounds.x).toBeCloseTo(-50);
+        expect(bounds.y).toBeCloseTo(0);
+        expect(bounds.width).toBeCloseTo(50);
+        expect(bounds.height).toBeCloseTo(100);
+    });
+
+    it('should match rotatePolygon + getPolygonBounds result', () => {
+        const poly = [{x:0, y:0}, {x:100, y:0}, {x:50, y:80}]; // Triangle
+        const angle = 45;
+
+        const rotated = GeometryUtil.rotatePolygon(poly, angle);
+        const expected = GeometryUtil.getPolygonBounds(rotated);
+        const actual = GeometryUtil.getRotatedPolygonBounds(poly, angle);
+
+        expect(actual.x).toBeCloseTo(expected.x);
+        expect(actual.y).toBeCloseTo(expected.y);
+        expect(actual.width).toBeCloseTo(expected.width);
+        expect(actual.height).toBeCloseTo(expected.height);
+    });
+
+    it('should handle 0 degrees optimization', () => {
+        const poly = [{x:0, y:0}, {x:100, y:0}, {x:100, y:50}, {x:0, y:50}];
+        const bounds = GeometryUtil.getRotatedPolygonBounds(poly, 0);
+        expect(bounds).toEqual({x:0, y:0, width:100, height:50});
+    });
+});


### PR DESCRIPTION
⚡ Bolt: Optimize rotated polygon bounds calculation

Optimized the `GeneticAlgorithm` and `PlacementWorker` hot loops by introducing `GeometryUtil.getRotatedPolygonBounds`. This method calculates the bounding box of a rotated polygon without allocating intermediate point objects or arrays, reducing memory pressure during the nesting process.

1.  Added `getRotatedPolygonBounds` to `src/lib/geometryutil.js`.
2.  Updated `GeneticAlgorithm` constructor in `src/lib/svgnest.js` to use the new method.
3.  Updated `applyPlacement` in `src/lib/svgnest.js` to use the new method.
4.  Updated `PlacementWorker.getBounds` in `src/lib/placementworker.js` to use the new method.
5.  Added unit tests in `tests/geometry_util.test.js`.

Impact:
- Reduces object allocations by `N` (points) * `Rotations` * `Population` per generation cycle (if used in mutation, but here used in init and placement checks).
- In `GeneticAlgorithm` init: avoids `N` allocations per rotation check.
- In `PlacementWorker` collision checks: avoids `N` allocations per placed part check.


---
*PR created automatically by Jules for task [13284496370840924258](https://jules.google.com/task/13284496370840924258) started by @LokiMetaSmith*