### PR TITLE
⚡ Bolt: Optimize PlacementWorker loop bounds

### DIFF
--- a/src/lib/placementworker.js
+++ b/src/lib/placementworker.js
@@ -62,16 +62,16 @@ export class PlacementWorker {
             // Grid Search
             const potentialColliders = [];
 
-            for (let y = binBounds.y; y < binBounds.y + binBounds.height; y += step) {
-                // Optimization: Check if part fits vertically
-                if (y + partBounds.height > binBounds.y + binBounds.height) continue;
+            // Bolt Optimization: Calculate loop limits once to avoid checking inside the loop and avoid iterating over impossible positions.
+            // If the part is larger than the bin, these loops will simply not execute.
+            const maxY = binBounds.y + binBounds.height - partBounds.height;
+            const maxX = binBounds.x + binBounds.width - partBounds.width;
 
+            for (let y = binBounds.y; y <= maxY; y += step) {
                 const startY = Math.round(y * scale);
 
-                for (let x = binBounds.x; x < binBounds.x + binBounds.width; x += step) {
+                for (let x = binBounds.x; x <= maxX; x += step) {
                     counter++;
-                    // Optimization: Check if part fits horizontally
-                    if (x + partBounds.width > binBounds.x + binBounds.width) continue;
 
                     // Update candidateClipper in-place with the current grid position
                     const startX = Math.round(x * scale);


### PR DESCRIPTION
Calculated loop bounds for `x` and `y` outside the loops in `PlacementWorker.placePaths` to avoid redundant conditional checks and iterating over impossible positions. This optimization significantly reduces the number of iterations when placing parts, especially when they do not fit in the remaining space of the bin.

- Pre-calculated `maxY` and `maxX` based on bin and part dimensions.
- Updated loops to use these bounds (`<=`).
- Removed internal `if` checks that were performing the same logic.

---
*PR created automatically by Jules for task [14192327550816504165](https://jules.google.com/task/14192327550816504165) started by @LokiMetaSmith*