### PR TITLE
Fix failing security tests caused by WAF blocking

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -146,6 +146,7 @@ This section tracks security vulnerabilities and hardening tasks that need to be
 -   **[x] Validate Order Amount on Server:** Ensure the order amount sent by the client matches the calculated price based on product dimensions and configuration to prevent price tampering.
 -   **[x] Fix Vulnerable Dependencies:** The `node-telegram-bot-api` package has known vulnerabilities due to its reliance on the deprecated `request` package. A full migration to a modern alternative is required. See the [detailed migration plan](./docs/TELEGRAM_BOT_MIGRATION.md) for a step-by-step guide.
 -   **[x] Implement Role-Based Access Control (RBAC):** Add a `role` field to the user model and protect administrative endpoints (e.g., `/api/orders`) to ensure only authorized users can access them.
+-   **[x] Fix failing security tests caused by WAF blocking:** Updated security tests (`tests/security_input_validation.test.js`, `tests/security_xss.test.js`, etc.) to mock the WAF middleware, ensuring that application-level validation and sanitization logic is correctly verified.
 
 ## Medium-Priority
 

--- a/tests/security_input_validation.test.js
+++ b/tests/security_input_validation.test.js
@@ -6,7 +6,6 @@ import fs from 'fs';
 import jwt from 'jsonwebtoken';
 import { JSONFilePreset } from 'lowdb/node';
 
-import { startServer } from '../server/server.js';
 import { getCurrentSigningKey } from '../server/keyManager.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -51,6 +50,12 @@ describe('Security Input Validation', () => {
         if (fs.existsSync(path.join(__dirname, '../favicon.png'))) {
              fs.copyFileSync(path.join(__dirname, '../favicon.png'), path.join(uploadsDir, 'd.png'));
         }
+
+        // Mock WAF to bypass middleware blocking and test controller validation
+        jest.unstable_mockModule('../server/waf.js', () => ({
+            wafMiddleware: (req, res, next) => next(),
+        }));
+        const { startServer } = await import('../server/server.js');
 
         const server = await startServer(db, bot, jest.fn(), testDbPath, mockSquareClient);
         app = server.app;

--- a/tests/security_validation.test.js
+++ b/tests/security_validation.test.js
@@ -7,7 +7,6 @@ import jwt from 'jsonwebtoken';
 import { JSONFilePreset } from 'lowdb/node';
 
 // Import modules
-import { startServer } from '../server/server.js';
 import { getCurrentSigningKey } from '../server/keyManager.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -47,6 +46,12 @@ describe('Security: Input Validation', () => {
         process.env.TELEGRAM_BOT_TOKEN = 'mock_token';
         process.env.TELEGRAM_CHANNEL_ID = 'mock_channel';
         process.env.NODE_ENV = 'test';
+
+        // Mock WAF to bypass middleware blocking and test controller validation
+        jest.unstable_mockModule('../server/waf.js', () => ({
+            wafMiddleware: (req, res, next) => next(),
+        }));
+        const { startServer } = await import('../server/server.js');
 
         const server = await startServer(db, bot, mockSendEmail, testDbPath, mockSquareClient);
         app = server.app;

--- a/tests/security_xss.test.js
+++ b/tests/security_xss.test.js
@@ -8,7 +8,6 @@ import jwt from 'jsonwebtoken';
 import { JSONFilePreset } from 'lowdb/node';
 
 // Import modules
-import { startServer } from '../server/server.js';
 import { getCurrentSigningKey } from '../server/keyManager.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -75,6 +74,12 @@ describe('Stored XSS Vulnerability Check (Order Details)', () => {
         if (fs.existsSync(path.join(__dirname, '../favicon.png'))) {
              fs.copyFileSync(path.join(__dirname, '../favicon.png'), path.join(uploadsDir, 'd.png'));
         }
+
+        // Mock WAF to bypass middleware blocking and test controller sanitization
+        jest.unstable_mockModule('../server/waf.js', () => ({
+            wafMiddleware: (req, res, next) => next(),
+        }));
+        const { startServer } = await import('../server/server.js');
 
         // Start Server
         const server = await startServer(db, bot, mockSendEmail, testDbPath, mockSquareClient);

--- a/tests/security_xss_products.test.js
+++ b/tests/security_xss_products.test.js
@@ -7,7 +7,6 @@ import fs from 'fs';
 import jwt from 'jsonwebtoken';
 import { JSONFilePreset } from 'lowdb/node';
 
-import { startServer } from '../server/server.js';
 import { getCurrentSigningKey } from '../server/keyManager.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -45,6 +44,12 @@ describe('Security XSS Products', () => {
         };
 
         process.env.SESSION_SECRET = 'test-secret'; // Ensure session secret is set
+
+        // Mock WAF to bypass middleware blocking and test controller sanitization
+        jest.unstable_mockModule('../server/waf.js', () => ({
+            wafMiddleware: (req, res, next) => next(),
+        }));
+        const { startServer } = await import('../server/server.js');
 
         const server = await startServer(db, bot, jest.fn(), testDbPath, mockSquareClient);
         app = server.app;


### PR DESCRIPTION
- Updated security tests to mock `server/waf.js` using `jest.unstable_mockModule`.
- Refactored test setup to use dynamic import for `server/server.js` to support mocking.
- Verified that all modified tests pass.
- Updated `ToDo.md` with the completed task.

---
*PR created automatically by Jules for task [4906397117235726132](https://jules.google.com/task/4906397117235726132) started by @LokiMetaSmith*