### PR TITLE
UX: Wrap login inputs in a semantic form

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-05-18 - Leveraging Existing Feedback Mechanisms
 **Learning:** The app uses a single `showPaymentStatus` container for all major feedback (loading, success, error), even outside of payment contexts (e.g., image generation). This provides a consistent location for users to look for updates.
 **Action:** Reuse `showPaymentStatus` for async operations like loading deep-linked content instead of creating new toast components.
+
+## 2026-02-08 - Native Form Behavior for Login
+**Learning:** Wrapping input fields in a `<form>` element is critical for accessibility and standard behavior (like submitting with the Enter key). Even if AJAX is used for submission, the form element provides semantic meaning and browser-native functionality that users expect.
+**Action:** Always check if input groups that function as a form are actually wrapped in a `<form>` tag.

--- a/printshop.html
+++ b/printshop.html
@@ -173,17 +173,17 @@
             <button id="close-modal-btn" class="text-2xl font-bold text-gray-500 hover:text-gray-800" aria-label="Close modal">&times;</button>
         </div>
 
-        <div class="space-y-4">
+        <form id="login-form" class="space-y-4">
             <div>
                 <label for="username-input" class="block font-bold">Username</label>
-                <input type="text" id="username-input" class="w-full p-2 border rounded-md">
+                <input type="text" id="username-input" name="username" class="w-full p-2 border rounded-md" autocomplete="username" required>
             </div>
             <div>
                 <label for="password-input" class="block font-bold">Password</label>
-                <input type="password" id="password-input" class="w-full p-2 border rounded-md">
+                <input type="password" id="password-input" name="password" class="w-full p-2 border rounded-md" autocomplete="current-password" required>
             </div>
-            <button id="password-login-btn" class="w-full px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600">Login with Password</button>
-        </div>
+            <button type="submit" id="password-login-btn" class="w-full px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600">Login with Password</button>
+        </form>
 
         <div class="my-6 flex items-center">
             <hr class="flex-grow border-t border-gray-300">

--- a/src/printshop.js
+++ b/src/printshop.js
@@ -838,7 +838,7 @@ export async function init() {
     await getServerSessionToken();
 
     // Assign all DOM elements to the ui object
-    const ids = ['orders-list', 'no-orders-message', 'refreshOrdersBtn', 'nestStickersBtn', 'nested-svg-container', 'spacingInput', 'addPrintingMarks', 'registerBtn', 'loginBtn', 'auth-status', 'loading-indicator', 'error-toast', 'error-message', 'close-error-toast', 'success-toast', 'success-message', 'close-success-toast', 'searchInput', 'searchBtn', 'downloadCutFileBtn', 'exportPdfBtn', 'login-modal', 'close-modal-btn', 'username-input', 'password-input', 'password-login-btn', 'webauthn-login-btn', 'webauthn-register-btn', 'connection-status-dot', 'connection-status-text'];
+    const ids = ['orders-list', 'no-orders-message', 'refreshOrdersBtn', 'nestStickersBtn', 'nested-svg-container', 'spacingInput', 'addPrintingMarks', 'registerBtn', 'loginBtn', 'auth-status', 'loading-indicator', 'error-toast', 'error-message', 'close-error-toast', 'success-toast', 'success-message', 'close-success-toast', 'searchInput', 'searchBtn', 'downloadCutFileBtn', 'exportPdfBtn', 'login-modal', 'close-modal-btn', 'username-input', 'password-input', 'password-login-btn', 'webauthn-login-btn', 'webauthn-register-btn', 'connection-status-dot', 'connection-status-text', 'login-form'];
     ids.forEach(id => {
         // Convert kebab-case to camelCase for keys
         const key = id.replace(/-(\w)/g, (match, letter) => letter.toUpperCase());
@@ -863,7 +863,10 @@ export async function init() {
 
     // Login Modal Listeners
     ui.closeModalBtn?.addEventListener('click', hideLoginModal);
-    ui.passwordLoginBtn?.addEventListener('click', handlePasswordLogin);
+    ui.loginForm?.addEventListener('submit', (e) => {
+        e.preventDefault();
+        handlePasswordLogin();
+    });
     ui.webauthnLoginBtn?.addEventListener('click', handleWebAuthnLogin);
     ui.webauthnRegisterBtn?.addEventListener('click', handleRegistration);
 

--- a/tests/frontend/login_form_structure.test.js
+++ b/tests/frontend/login_form_structure.test.js
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment jsdom
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+describe('Login Modal Structure', () => {
+    let html;
+
+    beforeAll(() => {
+        html = fs.readFileSync(path.resolve(__dirname, '../../printshop.html'), 'utf8');
+    });
+
+    beforeEach(() => {
+        document.documentElement.innerHTML = html;
+    });
+
+    test('Login inputs should be wrapped in a form', () => {
+        const usernameInput = document.getElementById('username-input');
+        const passwordInput = document.getElementById('password-input');
+        const form = usernameInput.closest('form');
+
+        expect(form).not.toBeNull();
+        expect(form.getAttribute('id')).toBe('login-form');
+        expect(form.contains(passwordInput)).toBe(true);
+    });
+
+    test('Login button should be type submit', () => {
+         const loginBtn = document.getElementById('password-login-btn');
+         expect(loginBtn.getAttribute('type')).toBe('submit');
+    });
+
+    test('Username input should have autocomplete and required', () => {
+        const usernameInput = document.getElementById('username-input');
+        expect(usernameInput.getAttribute('autocomplete')).toBe('username');
+        expect(usernameInput.hasAttribute('required')).toBe(true);
+    });
+
+    test('Password input should have autocomplete and required', () => {
+        const passwordInput = document.getElementById('password-input');
+        expect(passwordInput.getAttribute('autocomplete')).toBe('current-password');
+        expect(passwordInput.hasAttribute('required')).toBe(true);
+    });
+});


### PR DESCRIPTION
This PR improves the UX and accessibility of the login modal by wrapping the input fields in a semantic `<form>` element. This change enables users to submit the login form by pressing the Enter key, which is a standard expectation for web forms. Additionally, `autocomplete` attributes were added to help password managers correctly identify the fields, and `required` attributes were added for basic client-side validation. A regression test was added to verify these structural changes.

---
*PR created automatically by Jules for task [8270939314379480482](https://jules.google.com/task/8270939314379480482) started by @LokiMetaSmith*