### PR TITLE
Add tests for generateCutFile function

### DIFF
--- a/src/lib/cut_file_generator.js
+++ b/src/lib/cut_file_generator.js
@@ -1,0 +1,19 @@
+export function generateCutFile(svgString) {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(svgString, 'image/svg+xml');
+    const svgElement = doc.documentElement;
+    const cutFileSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    cutFileSvg.setAttribute('width', svgElement.getAttribute('width'));
+    cutFileSvg.setAttribute('height', svgElement.getAttribute('height'));
+    cutFileSvg.setAttribute('viewBox', svgElement.getAttribute('viewBox'));
+
+    // Support multiple shapes
+    svgElement.querySelectorAll('path, rect, circle, ellipse, polygon, polyline').forEach(el => {
+        const newEl = el.cloneNode(true);
+        newEl.setAttribute('stroke', 'red');
+        newEl.setAttribute('fill', 'none');
+        cutFileSvg.appendChild(newEl);
+    });
+
+    return new XMLSerializer().serializeToString(cutFileSvg);
+}

--- a/src/printshop.js
+++ b/src/printshop.js
@@ -4,6 +4,7 @@ import { startRegistration, startAuthentication } from '@simplewebauthn/browser'
 import DOMPurify from 'dompurify';
 import { SvgNest } from './lib/svgnest.js';
 import { SVGParser } from './lib/svgparser.js';
+import { generateCutFile } from './lib/cut_file_generator.js';
 import * as jose from 'jose';
 import { jsPDF } from "jspdf";
 import SVGtoPDF from 'svg-to-pdfkit';
@@ -697,26 +698,6 @@ async function handleNesting() {
     } finally {
         hideLoadingIndicator();
     }
-}
-
-function generateCutFile(svgString) {
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(svgString, 'image/svg+xml');
-    const svgElement = doc.documentElement;
-    const cutFileSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-    cutFileSvg.setAttribute('width', svgElement.getAttribute('width'));
-    cutFileSvg.setAttribute('height', svgElement.getAttribute('height'));
-    cutFileSvg.setAttribute('viewBox', svgElement.getAttribute('viewBox'));
-
-    // Support multiple shapes
-    svgElement.querySelectorAll('path, rect, circle, ellipse, polygon, polyline').forEach(el => {
-        const newEl = el.cloneNode(true);
-        newEl.setAttribute('stroke', 'red');
-        newEl.setAttribute('fill', 'none');
-        cutFileSvg.appendChild(newEl);
-    });
-
-    return new XMLSerializer().serializeToString(cutFileSvg);
 }
 
 function handleDownloadCutFile() {

--- a/tests/README.md
+++ b/tests/README.md
@@ -42,4 +42,3 @@ This directory contains the unit tests for the Print Shop application.
 ## Future Tests
 
 *   Add tests for the encryption/decryption of the client JSON file.
-*   Add tests for the `generateCutFile` function.

--- a/tests/frontend/cut_file_generator.test.js
+++ b/tests/frontend/cut_file_generator.test.js
@@ -1,0 +1,72 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { generateCutFile } from '../../src/lib/cut_file_generator.js';
+
+describe('generateCutFile', () => {
+    test('should copy dimensions and viewBox', () => {
+        const svgString = '<svg width="100" height="100" viewBox="0 0 100 100"></svg>';
+        const result = generateCutFile(svgString);
+
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(result, 'image/svg+xml');
+        const svg = doc.documentElement;
+
+        expect(svg.getAttribute('width')).toBe('100');
+        expect(svg.getAttribute('height')).toBe('100');
+        expect(svg.getAttribute('viewBox')).toBe('0 0 100 100');
+    });
+
+    test('should clone shapes with red stroke and no fill', () => {
+        const svgString = `
+            <svg width="100" height="100" viewBox="0 0 100 100">
+                <rect x="10" y="10" width="80" height="80" fill="blue" stroke="black" />
+                <circle cx="50" cy="50" r="40" fill="green" />
+            </svg>
+        `;
+        const result = generateCutFile(svgString);
+
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(result, 'image/svg+xml');
+        const rect = doc.querySelector('rect');
+        const circle = doc.querySelector('circle');
+
+        expect(rect).toBeTruthy();
+        expect(rect.getAttribute('x')).toBe('10');
+        expect(rect.getAttribute('fill')).toBe('none');
+        expect(rect.getAttribute('stroke')).toBe('red');
+
+        expect(circle).toBeTruthy();
+        expect(circle.getAttribute('cx')).toBe('50');
+        expect(circle.getAttribute('fill')).toBe('none');
+        expect(circle.getAttribute('stroke')).toBe('red');
+    });
+
+    test('should handle multiple shapes', () => {
+         const svgString = `
+            <svg width="100" height="100" viewBox="0 0 100 100">
+                <path d="M10 10 L90 90" />
+                <ellipse cx="50" cy="50" rx="40" ry="20" />
+                <polygon points="10,10 20,20 30,10" />
+                <polyline points="10,80 20,90 30,80" />
+            </svg>
+        `;
+        const result = generateCutFile(svgString);
+
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(result, 'image/svg+xml');
+
+        expect(doc.querySelectorAll('path').length).toBe(1);
+        expect(doc.querySelectorAll('ellipse').length).toBe(1);
+        expect(doc.querySelectorAll('polygon').length).toBe(1);
+        expect(doc.querySelectorAll('polyline').length).toBe(1);
+
+        doc.querySelectorAll('*').forEach(el => {
+            if (el.tagName !== 'svg') {
+                 expect(el.getAttribute('stroke')).toBe('red');
+                 expect(el.getAttribute('fill')).toBe('none');
+            }
+        });
+    });
+});


### PR DESCRIPTION
This PR addresses the task "Add tests for the `generateCutFile` function" from the TODO list. 

It refactors the `generateCutFile` function into a separate module to facilitate testing and adds comprehensive unit tests to verify its behavior, including copying dimensions, cloning shapes, and applying correct styling.

---
*PR created automatically by Jules for task [8717264493792567048](https://jules.google.com/task/8717264493792567048) started by @LokiMetaSmith*