### PR TITLE
Fix flaky E2E test due to shared file race condition

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -51,7 +51,7 @@ These are smaller tasks for improving test quality and covering minor edge cases
 -   **[x] Consolidate Redundant Tests:** The `/api/ping` endpoint is tested in two different files. The duplicate test should be removed.
 -   **[x] Fix Server Pricing Tests:** Fix the regression in `tests/server-pricing.test.js` where perimeters were checked against array length instead of calculated value.
 -   **[x] Remove Unused Dependency `lucas`:** This package appears to be a typo for `lusca` and is unused.
--   **[x] Fix E2E test warnings:** Fixed "Test image not found" warning in `verify_features.spec.js` and "Unhandled API route" warning in `test-setup.js`.
+-   **[x] Fix E2E test warnings:** Fixed "Test image not found" warning in `verify_features.spec.js` and "Unhandled API route" warning in `test-setup.js`. Fixed race condition in `verify_features.spec.js` causing failures.
 
 ---
 <br>

--- a/playwright_tests/verify_features.spec.js
+++ b/playwright_tests/verify_features.spec.js
@@ -3,7 +3,7 @@ import { test, expect } from './test-setup.js';
 import fs from 'fs';
 import path from 'path';
 
-const TEST_IMAGE_PATH = path.join('verification', 'test.png');
+const TEST_IMAGE_PATH = path.join('verification', 'test_features.png');
 
 test.beforeAll(() => {
     if (!fs.existsSync(TEST_IMAGE_PATH)) {
@@ -14,6 +14,12 @@ test.beforeAll(() => {
         // Create a dummy image (red pixel)
         const buffer = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==', 'base64');
         fs.writeFileSync(TEST_IMAGE_PATH, buffer);
+    }
+});
+
+test.afterAll(() => {
+    if (fs.existsSync(TEST_IMAGE_PATH)) {
+        fs.unlinkSync(TEST_IMAGE_PATH);
     }
 });
 


### PR DESCRIPTION
This PR addresses a race condition in the Playwright E2E test suite.

**The Problem:**
`playwright_tests/verify_features.spec.js` and `playwright_tests/payment-form.spec.js` both used the same file path (`verification/test.png`) for testing. Since tests run in parallel, `payment-form.spec.js`'s `afterAll` hook was deleting the file while `verify_features.spec.js` was trying to use it, leading to `ENOENT` errors.

**The Fix:**
- Updated `playwright_tests/verify_features.spec.js` to use a unique filename: `verification/test_features.png`.
- Added an `afterAll` hook to `verify_features.spec.js` to clean up this specific file.
- Updated `ToDo.md` to note the fix.

**Verification:**
Ran `pnpm test` and confirmed all 238 tests passed.

---
*PR created automatically by Jules for task [12201728244963990996](https://jules.google.com/task/12201728244963990996) started by @LokiMetaSmith*