### PR TITLE
🛡️ Sentinel: Fix WebAuthn authentication endpoints

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -26,7 +26,7 @@ import { sendEmail as defaultSendEmail } from './email.js';
 import { getCurrentSigningKey, getJwks, rotateKeys, getKey, KEY_ROTATION_MS } from './keyManager.js';
 import { initializeBot } from './bot.js';
 import { initializeTracker } from './tracker.js';
-import { validateUsername, validateId } from './validators.js';
+import { validateUsername, validateUsernameQuery, validateId } from './validators.js';
 import { fileTypeFromFile } from 'file-type';
 import { calculateStickerPrice, getDesignDimensions } from './pricing.js';
 import { Markup } from 'telegraf';
@@ -1707,8 +1707,12 @@ async function startServer(
     });
 
     app.post('/api/auth/register-verify', authLimiter, validateUsername, async (req, res) => {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) {
+        return res.status(400).json({ errors: errors.array() });
+      }
       const { body } = req;
-      const { username } = req.query;
+      const { username } = req.body;
       // Prevent prototype pollution
       if (['__proto__', 'constructor', 'prototype'].includes(username)) {
         return res.status(400).json({ error: 'Invalid username.' });
@@ -1736,7 +1740,11 @@ async function startServer(
       }
     });
 
-    app.get('/api/auth/login-options', authLimiter, validateUsername, async (req, res) => {
+    app.get('/api/auth/login-options', authLimiter, validateUsernameQuery, async (req, res) => {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) {
+        return res.status(400).json({ errors: errors.array() });
+      }
       const { username } = req.query;
       // Prevent prototype pollution
       if (['__proto__', 'constructor', 'prototype'].includes(username)) {
@@ -1759,8 +1767,12 @@ async function startServer(
     });
 
     app.post('/api/auth/login-verify', authLimiter, validateUsername, async (req, res) => {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) {
+        return res.status(400).json({ errors: errors.array() });
+      }
       const { body } = req;
-      const { username } = req.query;
+      const { username } = req.body;
       // Prevent prototype pollution
       if (['__proto__', 'constructor', 'prototype'].includes(username)) {
         return res.status(400).json({ error: 'Invalid username.' });

--- a/server/validators.js
+++ b/server/validators.js
@@ -1,4 +1,4 @@
-import { body, param } from 'express-validator';
+import { body, param, query } from 'express-validator';
 
 // Basic username sanitization to prevent prototype pollution
 const sanitizeUsername = (username) => {
@@ -22,6 +22,19 @@ export const isValidId = (id) => {
 // Reusable username validation middleware
 export const validateUsername = [
   body('username')
+    .notEmpty().withMessage('Username is required')
+    .isString().withMessage('Username must be a string')
+    .custom(value => {
+      if (sanitizeUsername(value) === null) {
+        throw new Error('Invalid username');
+      }
+      return true;
+    }),
+];
+
+// Reusable username validation middleware for query params
+export const validateUsernameQuery = [
+  query('username')
     .notEmpty().withMessage('Username is required')
     .isString().withMessage('Username must be a string')
     .custom(value => {

--- a/tests/auth-webauthn.test.js
+++ b/tests/auth-webauthn.test.js
@@ -92,9 +92,10 @@ describe('WebAuthn Endpoints', () => {
         csrfToken = csrfRes.body.csrfToken;
 
         const res = await agent
-            .post(`/api/auth/register-verify?username=${username}`)
+            .post('/api/auth/register-verify')
             .set('X-CSRF-Token', csrfToken)
             .send({
+                username,
                 id: 'Y3JlZC1pZC0xMjM', // Base64URL encoded 'cred-id-123'
                 response: {}
             });
@@ -131,9 +132,10 @@ describe('WebAuthn Endpoints', () => {
         mockWebAuthn.verifyAuthenticationResponse.mockResolvedValue({ verified: true });
 
         const res = await agent
-            .post(`/api/auth/login-verify?username=${username}`)
+            .post('/api/auth/login-verify')
             .set('X-CSRF-Token', csrfToken)
             .send({
+                username,
                 id: 'cred-id-123',
                 response: {}
             });


### PR DESCRIPTION
- Fixed `POST /api/auth/register-verify` and `POST /api/auth/login-verify` to read `username` from `req.body` instead of `req.query`, fixing a broken authentication flow where the client sent data in the body but the server expected it in the query string.
- Added `validationResult(req)` checks to `register-verify` and `login-verify` to ensure input validation is actually enforced.
- Fixed `GET /api/auth/login-options` to use `validateUsernameQuery` (validating query params instead of body) and added `validationResult(req)` check.
- Updated `tests/auth-webauthn.test.js` to reflect the correct API contract (username in body for POST).

---
*PR created automatically by Jules for task [11768916568296525499](https://jules.google.com/task/11768916568296525499) started by @LokiMetaSmith*