### PR TITLE
⚡ Bolt: Enable Gzip and caching in Nginx

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -26,11 +26,24 @@ server {
     # HSTS (63072000 seconds)
     add_header Strict-Transport-Security "max-age=63072000" always;
 
+    # Gzip Compression
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types text/plain text/css text/xml application/json application/javascript application/rss+xml application/atom+xml image/svg+xml;
+
     root /usr/share/nginx/html;
     index index.html;
 
     location / {
         try_files $uri $uri/ =404;
+    }
+
+    # Static Assets Caching
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+        expires 30d;
+        add_header Cache-Control "public, no-transform";
     }
 
     location /api/ {


### PR DESCRIPTION
💡 What: Enabled Gzip compression and browser caching for static assets in Nginx configuration.
🎯 Why: To improve frontend performance by reducing payload size and leveraging browser caching, leading to faster load times and reduced bandwidth usage.
📊 Impact: Expected reduction in transfer size for text-based assets (HTML, CSS, JS, SVG) and fewer requests for static assets on repeat visits.
🔬 Measurement: Verify response headers `Content-Encoding: gzip` and `Cache-Control` for static assets in production environment.

---
*PR created automatically by Jules for task [15054626246936408386](https://jules.google.com/task/15054626246936408386) started by @LokiMetaSmith*