### PR TITLE
feat(ui): add icons to order history buttons and improve form validation

### DIFF
--- a/orders.html
+++ b/orders.html
@@ -45,12 +45,27 @@
             placeholder="you@example.com"
             class="input flex-grow"
             aria-label="Email address for login"
+            required
           />
           <button
             type="submit"
             id="loginBtn"
             class="bg-splotch-red hover:brightness-110 text-white font-semibold py-2 px-4 rounded-full flex justify-center items-center gap-2"
           >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke-width="1.5"
+              stroke="currentColor"
+              class="w-5 h-5"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456zM16.894 20.567L16.5 21.75l-.394-1.183a2.25 2.25 0 00-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 001.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 001.423 1.423l1.183.394-1.183.394a2.25 2.25 0 00-1.423 1.423z"
+              />
+            </svg>
             Send Magic Link
           </button>
         </form>
@@ -119,14 +134,42 @@
         <div class="flex flex-wrap gap-4">
           <button
             id="exportDataBtn"
-            class="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded-md"
+            class="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded-md flex items-center gap-2"
           >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke-width="1.5"
+              stroke="currentColor"
+              class="w-5 h-5"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
+              />
+            </svg>
             Export My Data
           </button>
           <button
             id="deleteAccountBtn"
-            class="bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded-md"
+            class="bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded-md flex items-center gap-2"
           >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke-width="1.5"
+              stroke="currentColor"
+              class="w-5 h-5"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+              />
+            </svg>
             Delete Account
           </button>
         </div>

--- a/playwright_tests/verify_ux_icons.spec.js
+++ b/playwright_tests/verify_ux_icons.spec.js
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+test('Verify UX icons and required attribute in orders.html', async ({ page }) => {
+  // Navigate to the orders page
+  await page.goto('/orders.html');
+
+  // Verify email input has the required attribute
+  const emailInput = page.locator('#emailInput');
+  await expect(emailInput).toHaveAttribute('required', '');
+
+  // Verify Login Button has an SVG icon
+  // The button text is "Send Magic Link", but we check for SVG inside it
+  const loginBtnSvg = page.locator('#loginBtn svg');
+  await expect(loginBtnSvg).toHaveCount(1);
+
+  // Verify Export Data Button has an SVG icon
+  // Note: These buttons might be inside a hidden section, but we check presence in DOM
+  const exportBtnSvg = page.locator('#exportDataBtn svg');
+  await expect(exportBtnSvg).toHaveCount(1);
+
+  // Verify Delete Account Button has an SVG icon
+  const deleteBtnSvg = page.locator('#deleteAccountBtn svg');
+  await expect(deleteBtnSvg).toHaveCount(1);
+});


### PR DESCRIPTION
This PR enhances the UX and Accessibility of the Order History page (`orders.html`) by adding visual cues (SVG icons) to key action buttons and enforcing native HTML form validation on the login email input. A Playwright test is included to verify these changes.

---
*PR created automatically by Jules for task [15092135886506269432](https://jules.google.com/task/15092135886506269432) started by @LokiMetaSmith*