### PR TITLE
feat: add Lite deployment tier for cost-effective hosting

### DIFF
--- a/docker-compose.lite.yml
+++ b/docker-compose.lite.yml
@@ -1,0 +1,48 @@
+version: '3.8'
+services:
+  app:
+    build:
+      context: ./server
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      - DB_PROVIDER=lowdb
+      - DB_PATH=/app/db.json
+      # In Lite mode, we enable bot polling in the main app container
+      # since we are running a single instance.
+      - ENABLE_BOT_POLLING=true
+      - ENABLE_WEB_SERVER=true
+    volumes:
+      - /home/loki/app-data/uploads:/app/server/uploads
+      - /home/loki/app-data/db.json:/app/db.json
+    depends_on:
+      - redis
+    networks:
+      - app-net
+
+  redis:
+    image: redis:alpine
+    restart: unless-stopped
+    volumes:
+      - /home/loki/app-data/redis:/data
+    networks:
+      - app-net
+
+  nginx:
+    image: nginx:latest
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf
+      - ./dist:/usr/share/nginx/html
+      - /home/loki/ssl:/etc/ssl:ro
+    depends_on:
+      - app
+    networks:
+      - app-net
+
+networks:
+  app-net:
+    driver: bridge

--- a/docs/PLAN_RECOMMENDATION.md
+++ b/docs/PLAN_RECOMMENDATION.md
@@ -1,0 +1,57 @@
+# Deployment Plan Recommendation
+
+This document outlines the recommended DigitalOcean Droplet sizes and configurations for deploying the Print Shop application. We offer two primary deployment tiers: **Lite** and **Standard**.
+
+## 1. Lite Tier (Recommended for New Starts & Low Cost)
+
+The **Lite** tier is optimized for cost-efficiency and is suitable for small shops, testing, or environments with low traffic. It uses a consolidated architecture to minimize resource usage.
+
+*   **Cost:** ~$6/mo
+*   **Droplet Size:** `s-1vcpu-1gb` (1GB RAM, 1 vCPU)
+*   **Architecture:**
+    *   **Database:** LowDB (File-based JSON database). Extremely lightweight but not suitable for high-concurrency writes.
+    *   **Services:** Runs the Web Server and Telegram Bot in a single container.
+    *   **Redundancy:** Single instance (no replicas).
+*   **Use Case:**
+    *   Small print shops with low order volume.
+    *   Testing and development environments.
+    *   Users who want to minimize hosting costs.
+
+**To Deploy Lite Tier:**
+```bash
+./scripts/deploy-digitalocean.sh my-print-shop-lite --lite
+```
+
+---
+
+## 2. Standard Tier (Recommended for Production)
+
+The **Standard** tier is designed for robustness, scalability, and higher traffic. It uses enterprise-grade components.
+
+*   **Cost:** ~$12/mo
+*   **Droplet Size:** `s-1vcpu-2gb` (2GB RAM, 1 vCPU)
+*   **Architecture:**
+    *   **Database:** MongoDB. Robust, scalable, and handles high concurrency.
+    *   **Services:** Runs Web Server and Telegram Bot in separate, specialized containers.
+    *   **Redundancy:** Runs 2 replicas of the application server for high availability.
+*   **Use Case:**
+    *   Active print shops with regular traffic.
+    *   Mission-critical deployments requiring higher uptime guarantees.
+    *   Future-proofing for growth.
+
+**To Deploy Standard Tier:**
+```bash
+./scripts/deploy-digitalocean.sh my-print-shop-prod
+```
+
+## Summary of Trade-offs
+
+| Feature | Lite Tier ($6/mo) | Standard Tier ($12/mo) |
+| :--- | :--- | :--- |
+| **RAM** | 1 GB | 2 GB |
+| **Database** | LowDB (File/JSON) | MongoDB |
+| **Concurrency** | Limited (File Locking) | High |
+| **Availability** | Single Instance | High (2 Replicas) |
+| **Complexity** | Low | Medium |
+
+**Recommendation:** Start with the **Lite** tier if you are just launching or have a limited budget. You can upgrade to the Standard tier later by migrating your data from LowDB to MongoDB and resizing your Droplet.

--- a/docs/digitalocean-cloud-config.yml
+++ b/docs/digitalocean-cloud-config.yml
@@ -115,7 +115,7 @@ runcmd:
   - cd /home/loki/lokimetasmith.github.io && npm install && npm run build
   # 5. Launch the application using Docker Compose in detached mode
   # Note: We use docker-compose.prod.yml which is now part of the repository
-  - cd /home/loki/lokimetasmith.github.io && docker-compose -f docker-compose.prod.yml up -d
+  - cd /home/loki/lokimetasmith.github.io && docker-compose -f DOCKER_COMPOSE_FILENAME up -d
   # 6. Create ACME challenge directory
   - mkdir -p /home/loki/lokimetasmith.github.io/dist/.well-known/acme-challenge
   - chown -R loki:loki /home/loki/lokimetasmith.github.io/dist/.well-known
@@ -140,7 +140,7 @@ runcmd:
   # 9. Get the initial certificate and reload nginx
   - |
     runuser -l loki -c 'getssl -f YOUR_DOMAIN_OR_IP'
-  - cd /home/loki/lokimetasmith.github.io && docker-compose -f docker-compose.prod.yml exec nginx nginx -s reload
+  - cd /home/loki/lokimetasmith.github.io && docker-compose -f DOCKER_COMPOSE_FILENAME exec nginx nginx -s reload
   # 10. Set up cron job for renewal
   - |
-    (crontab -l -u loki 2>/dev/null; echo "0 1 * * * /usr/bin/getssl -u -a -q && /usr/bin/docker-compose -f /home/loki/lokimetasmith.github.io/docker-compose.prod.yml exec nginx nginx -s reload") | crontab -u loki -
+    (crontab -l -u loki 2>/dev/null; echo "0 1 * * * /usr/bin/getssl -u -a -q && /usr/bin/docker-compose -f /home/loki/lokimetasmith.github.io/DOCKER_COMPOSE_FILENAME exec nginx nginx -s reload") | crontab -u loki -


### PR DESCRIPTION
This PR introduces a "Lite" deployment tier designed for cost-effective hosting on DigitalOcean, targeting the $6/mo (1GB RAM) droplet size.

Key changes:
- Created `docker-compose.lite.yml`: Replaces MongoDB with LowDB (file-based) and runs the app and bot in a single container instance to minimize RAM usage.
- Updated `scripts/deploy-digitalocean.sh`: Added a `--lite` flag. When used, it provisions an `s-1vcpu-1gb` droplet and injects the lite compose file into the cloud-config. The default behavior remains `s-1vcpu-2gb` with the standard production stack.
- Updated `docs/digitalocean-cloud-config.yml`: Replaced the hardcoded `docker-compose.prod.yml` reference with a placeholder `DOCKER_COMPOSE_FILENAME` to enable dynamic selection.
- Added `docs/PLAN_RECOMMENDATION.md`: A guide explaining the differences between the Lite and Standard tiers, including costs and trade-offs.

---
*PR created automatically by Jules for task [52539335962133914](https://jules.google.com/task/52539335962133914) started by @LokiMetaSmith*