### PR TITLE
Fix unhandled API route /api/inventory in E2E tests

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -52,6 +52,7 @@ These are smaller tasks for improving test quality and covering minor edge cases
 -   **[x] Fix Server Pricing Tests:** Fix the regression in `tests/server-pricing.test.js` where perimeters were checked against array length instead of calculated value.
 -   **[x] Remove Unused Dependency `lucas`:** This package appears to be a typo for `lusca` and is unused.
 -   **[x] Fix E2E test warnings:** Fixed "Test image not found" warning in `verify_features.spec.js` and "Unhandled API route" warning in `test-setup.js`. Fixed race condition in `verify_features.spec.js` causing failures.
+-   **[x] Fix regression:** Fixed unhandled API route /api/inventory in E2E tests.
 
 ---
 <br>

--- a/playwright_tests/test-setup.js
+++ b/playwright_tests/test-setup.js
@@ -134,6 +134,14 @@ export const test = base.extend({
                 });
             }
 
+            if (pathname.endsWith('/api/inventory')) {
+                return route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({})
+                });
+            }
+
             // Fallback for unhandled API routes
             console.warn(`[MOCK] Unhandled API route: ${pathname}`);
             return route.fulfill({


### PR DESCRIPTION
Fixes a regression where `/api/inventory` was not mocked in E2E tests, causing warnings and potential flakiness.
- Added mock handler for `/api/inventory` in `playwright_tests/test-setup.js`.
- Updated `ToDo.md` to track the fix.

---
*PR created automatically by Jules for task [1508775904102104251](https://jules.google.com/task/1508775904102104251) started by @LokiMetaSmith*