### PR TITLE
⚡ Bolt: Optimize scanline active list sorting

### DIFF
--- a/src/lib/placementworker.js
+++ b/src/lib/placementworker.js
@@ -87,7 +87,7 @@ export class PlacementWorker {
                 }
 
                 // Bolt Optimization: Sort active items by X coordinate to enable early break in the inner loop
-                activePlacedItems.sort((a, b) => a.bounds.x - b.bounds.x);
+                // Removed redundant sort: activePlacedItems is populated from placedItems which is maintained in X-sorted order.
 
                 for (let x = binBounds.x; x <= maxX; x += step) {
                     counter++;
@@ -167,6 +167,10 @@ export class PlacementWorker {
                     // Bolt Optimization: Create candidateRect only on successful placement
                     const candidateRect = { x: x, y: y, width: partBounds.width, height: partBounds.height };
                     placedItems.push({ path: placedPath, bounds: candidateRect });
+
+                    // Bolt Optimization: Keep placedItems sorted by X so activePlacedItems is automatically sorted
+                    placedItems.sort((a, b) => a.bounds.x - b.bounds.x);
+
                     placed = true;
                     break;
                 }


### PR DESCRIPTION
💡 What: Optimized `PlacementWorker.placePaths` to maintain `placedItems` in X-sorted order upon insertion, allowing the removal of redundant sorting of `activePlacedItems` inside the hot Y-scan loop.

🎯 Why: The previous implementation re-sorted the `activePlacedItems` list (a subset of placed items) for every step of the Y-scan loop during collision detection. This resulted in O(N * H) sorting operations per part, where N is the number of placed items and H is the grid height.

📊 Impact: Reduces sorting complexity to O(N) per part (a single sort after placement). For complex nestings with many parts and a fine grid, this significantly reduces CPU cycles spent in the inner loop.

🔬 Measurement: Verified with `tests/svgnest.test.js` to ensure placement logic and collision detection remain correct. Verified with `playwright_tests/nesting.spec.cjs` to ensure end-to-end nesting functionality works as expected.

---
*PR created automatically by Jules for task [5523709723964431884](https://jules.google.com/task/5523709723964431884) started by @LokiMetaSmith*