### PR TITLE
Make Square environment configurable and update env documentation

### DIFF
--- a/server/ENV_DOCUMENTATION.md
+++ b/server/ENV_DOCUMENTATION.md
@@ -10,14 +10,48 @@ This document explains the environment variables used in this project. These var
 
 ## Square Credentials
 
--   `SQUARE_ACCESS_TOKEN`: Your Square Sandbox access token. This is required for processing payments.
--   `SQUARE_LOCATION_ID`: Your Square Sandbox location ID. This is required for processing payments.
+-   `SQUARE_ENVIRONMENT`: Set to `production` for live transactions or `sandbox` for testing. Defaults to `sandbox`.
+-   `SQUARE_ACCESS_TOKEN`: Your Square access token. This is required for processing payments.
+-   `SQUARE_LOCATION_ID`: Your Square location ID. This is required for processing payments.
 
 ## Google OAuth Credentials
+
+> **Note:** The redirect URI used for OAuth is automatically constructed as `{BASE_URL}/oauth2callback`. Ensure this URI is added to your Authorized Redirect URIs in the Google Cloud Console.
+
 
 -   `GOOGLE_CLIENT_ID`: Your Google API client ID. This is used for authenticating with Google to send emails and for Google login.
 -   `GOOGLE_CLIENT_SECRET`: Your Google API client secret.
 -   `GMAIL_REFRESH_TOKEN`: The refresh token for the GMail API. This is obtained after the admin authenticates for the first time and is used to send emails. It is stored in `db.json` after the first authentication, but can be set here as a backup.
+
+## Storage Configuration (Optional)
+
+By default, files are stored locally in the `server/uploads` directory. To use S3-compatible object storage, configure the following:
+
+-   `STORAGE_PROVIDER`: Set to `s3` to enable object storage. Defaults to `local`.
+-   `S3_BUCKET`: The name of your S3 bucket.
+-   `S3_REGION`: The region of your S3 bucket (e.g., `us-east-1`).
+-   `S3_ENDPOINT`: (Optional) The endpoint URL for non-AWS S3 providers (e.g., `https://nyc3.digitaloceanspaces.com`).
+-   `AWS_ACCESS_KEY_ID`: Your AWS or S3 provider access key ID.
+-   `AWS_SECRET_ACCESS_KEY`: Your AWS or S3 provider secret access key.
+
+## Odoo Integration (Optional)
+
+To enable integration with Odoo for inventory management or other features:
+
+-   `ODOO_URL`: The URL of your Odoo instance (e.g., `https://your-odoo-instance.com`).
+-   `ODOO_DB`: The name of your Odoo database.
+-   `ODOO_USERNAME`: The username for Odoo authentication.
+-   `ODOO_PASSWORD`: The password (or API key) for Odoo authentication.
+
+## Error Tracking (Optional)
+
+-   `SENTRY_DSN`: The Data Source Name (DSN) for Sentry error tracking. If provided, server errors will be reported to Sentry.
+
+## Redis Configuration (Optional)
+
+For production environments, Redis is recommended for session storage and rate limiting.
+
+-   `REDIS_URL`: The connection string for your Redis instance (e.g., `redis://localhost:6379`).
 
 ## Admin Configuration
 

--- a/server/env.example
+++ b/server/env.example
@@ -6,6 +6,8 @@ NODE_ENV="development"
 DB_PATH="server/db.json"
 
 # Square Credentials
+# Set to "production" for live transactions, or "sandbox" for testing.
+SQUARE_ENVIRONMENT="sandbox"
 SQUARE_ACCESS_TOKEN="YOUR_SANDBOX_ACCESS_TOKEN"
 SQUARE_LOCATION_ID="YOUR_SANDBOX_LOCATION_ID"
 
@@ -26,6 +28,9 @@ EXPECTED_ORIGIN="http://localhost:5173"
 # Telegram Bot Configuration
 TELEGRAM_BOT_TOKEN="YOUR_TELEGRAM_BOT_TOKEN"
 TELEGRAM_CHANNEL_ID="YOUR_TELEGRAM_CHANNEL_ID"
+
+# Shipment Tracking
+EASYPOST_API_KEY="your-easypost-api-key"
 
 # Security and Session Management
 # SESSION_SECRET: Used to sign session cookies.

--- a/server/server.js
+++ b/server/server.js
@@ -353,11 +353,17 @@ async function startServer(
           process.exit(1);
         }
       }
+      // Determine Square Environment
+      const squareEnv = (getSecret('SQUARE_ENVIRONMENT') || 'sandbox').toLowerCase() === 'production'
+          ? SquareEnvironment.Production
+          : SquareEnvironment.Sandbox;
+
       squareClient = new SquareClient({
         version: '2025-07-16',
         token: getSecret('SQUARE_ACCESS_TOKEN'),
-        environment: SquareEnvironment.Sandbox,
+        environment: squareEnv,
       });
+      logger.info(`[SERVER] Square client initialized in ${squareEnv === SquareEnvironment.Production ? 'PRODUCTION' : 'SANDBOX'} mode.`);
       logger.info('[SERVER] Verifying connection to Square servers...');
     } else {
       logger.info('[SERVER] Using injected Square client.');


### PR DESCRIPTION
This change addresses missing environment variable documentation and makes the Square environment configurable.

Previously, the Square environment was hardcoded to `Sandbox`. It now respects the `SQUARE_ENVIRONMENT` variable (case-insensitive), defaulting to `Sandbox` if not set to `production`.

The following environment variables were added to `server/ENV_DOCUMENTATION.md` and/or `server/env.example`:
- `SQUARE_ENVIRONMENT`
- `EASYPOST_API_KEY`
- `STORAGE_PROVIDER`, `S3_*`, `AWS_*`
- `ODOO_*`
- `SENTRY_DSN`
- `REDIS_URL`

Verified by running server unit tests (`server/pnpm test`).

---
*PR created automatically by Jules for task [5939127020464270007](https://jules.google.com/task/5939127020464270007) started by @LokiMetaSmith*