### PR TITLE
feat: strict validation for magic link verification

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -156,6 +156,7 @@ This section tracks security vulnerabilities and hardening tasks that need to be
 -   **[x] Remove Fallback Session Secret:** Remove the hardcoded fallback session secret from `server/server.js` to ensure the application fails securely if the secret is not provided.
 -   **[x] Harden Docker Image:** Modify `server/Dockerfile` to create and use a non-root user to run the application, reducing the risk of container-based attacks.
 -   **[x] Improve Input Validation:** Perform a full audit of all API endpoints and apply consistent, strict input validation to all user-supplied data (including URL parameters, query strings, and request bodies).
+    -   [x] Add strict validation to /api/auth/verify-magic-link
 -   **[x] Remove duplicated price validation logic:** Removed redundant code block in `server/server.js` that performed price validation twice.
 
 ## Low-Priority

--- a/server/server.js
+++ b/server/server.js
@@ -1634,11 +1634,15 @@ async function startServer(
         }
     });
     
-    app.post('/api/auth/verify-magic-link', (req, res) => {
-      const { token } = req.body;
-      if (!token) {
-        return res.status(400).json({ error: 'No token provided' });
+    app.post('/api/auth/verify-magic-link', [
+        body('token').notEmpty().withMessage('Token is required').isString().withMessage('Token must be a string'),
+    ], (req, res) => {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) {
+        return res.status(400).json({ errors: errors.array() });
       }
+      const { token } = req.body;
+
       const { publicKey } = getCurrentSigningKey();
       jwt.verify(token, publicKey, { algorithms: ['RS256'] }, async (err, decoded) => {
         if (err) {

--- a/tests/auth_magic_link_validation.test.js
+++ b/tests/auth_magic_link_validation.test.js
@@ -1,0 +1,100 @@
+import { describe, beforeAll, beforeEach, afterAll, it, expect, jest } from '@jest/globals';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import request from 'supertest';
+import fs from 'fs';
+import { JSONFilePreset } from 'lowdb/node';
+import { startServer } from '../server/server.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+describe('Auth Magic Link Input Validation', () => {
+    let app;
+    let db;
+    let bot;
+    let serverInstance;
+    let timers;
+    const testDbPath = path.join(__dirname, 'test-db-magic-link-val.json');
+
+    beforeAll(async () => {
+        if (fs.existsSync(testDbPath)) {
+            fs.unlinkSync(testDbPath);
+        }
+        db = await JSONFilePreset(testDbPath, { orders: {}, users: {}, credentials: {}, config: {}, products: {} });
+
+        bot = {
+            telegram: {
+                sendMessage: jest.fn().mockResolvedValue({ message_id: 123 }),
+                editMessageText: jest.fn().mockResolvedValue(true),
+                deleteMessage: jest.fn().mockResolvedValue(true)
+            },
+            stopPolling: jest.fn()
+        };
+
+        const mockSendEmail = jest.fn().mockResolvedValue(true);
+        const mockSquareClient = {
+             locations: { list: jest.fn() },
+             payments: { create: jest.fn() }
+        };
+
+        process.env.ADMIN_EMAIL = 'admin@example.com';
+        process.env.NODE_ENV = 'test';
+        // Need to set a session secret to avoid fatal error
+        process.env.SESSION_SECRET = 'test-secret-12345678901234567890';
+
+        const server = await startServer(db, bot, mockSendEmail, testDbPath, mockSquareClient);
+        app = server.app;
+        timers = server.timers;
+        serverInstance = app.listen();
+    });
+
+    afterAll(async () => {
+        if (timers) timers.forEach(timer => clearInterval(timer));
+        if (serverInstance) await new Promise(resolve => serverInstance.close(resolve));
+        if (fs.existsSync(testDbPath)) {
+            fs.unlinkSync(testDbPath);
+        }
+    });
+
+    describe('POST /api/auth/verify-magic-link', () => {
+        it('should return 400 for non-string token (object)', async () => {
+            const agent = request.agent(app);
+            const csrfRes = await agent.get('/api/csrf-token');
+            const csrfToken = csrfRes.body.csrfToken;
+
+            const res = await agent
+                .post('/api/auth/verify-magic-link')
+                .set('X-CSRF-Token', csrfToken)
+                .send({ token: { foo: 'bar' } });
+
+            expect(res.statusCode).toBe(400);
+        });
+
+        it('should return 400 for non-string token (number)', async () => {
+            const agent = request.agent(app);
+            const csrfRes = await agent.get('/api/csrf-token');
+            const csrfToken = csrfRes.body.csrfToken;
+
+            const res = await agent
+                .post('/api/auth/verify-magic-link')
+                .set('X-CSRF-Token', csrfToken)
+                .send({ token: 12345 });
+
+            expect(res.statusCode).toBe(400);
+        });
+
+        it('should return 400 for empty token', async () => {
+             const agent = request.agent(app);
+             const csrfRes = await agent.get('/api/csrf-token');
+             const csrfToken = csrfRes.body.csrfToken;
+
+             const res = await agent
+                .post('/api/auth/verify-magic-link')
+                .set('X-CSRF-Token', csrfToken)
+                .send({ token: '' });
+
+            expect(res.statusCode).toBe(400);
+        });
+    });
+});


### PR DESCRIPTION
This PR improves the security and stability of the application by enforcing strict input validation on the `/api/auth/verify-magic-link` endpoint. Previously, the endpoint did not verify the type of the `token` parameter, relying on the `jsonwebtoken` library to handle invalid types (which resulted in a 401 Unauthorized or potentially synchronous errors). The new implementation uses `express-validator` to explicitly check that the token is a string, returning a 400 Bad Request with a clear validation error message if it is not. This aligns with the "Improve Input Validation" task in the ToDo list. A new test suite was added to verify the fix and prevent regressions.

---
*PR created automatically by Jules for task [11099248297654051325](https://jules.google.com/task/11099248297654051325) started by @LokiMetaSmith*