### PR TITLE
Relax SESSION_SECRET requirement for development environment

### DIFF
--- a/server/ENV_DOCUMENTATION.md
+++ b/server/ENV_DOCUMENTATION.md
@@ -78,6 +78,9 @@ For production environments, Redis is recommended for session storage and rate l
 ## Security and Session Management
 
 -   `SESSION_SECRET`: A secret key for signing the session ID cookie.
+    -   **Required in Production.**
+    -   In development (when `NODE_ENV` is not `production`), a default weak secret is used if this is not set.
+    -   Generate a strong random string (e.g., `openssl rand -base64 32`) for production use.
 -   `CSRF_SECRET`: A secret key for CSRF protection.
 -   `JWT_PRIVATE_KEY`: The private key for signing JSON Web Tokens (JWTs). If not provided, a new key will be generated on server startup. The key should be in PEM format.
 -   `JWT_PUBLIC_KEY`: The public key for verifying JSON Web Tokens (JWTs). If not provided, a new key will be generated on server startup. The key should be in PEM format.

--- a/server/server.js
+++ b/server/server.js
@@ -511,11 +511,18 @@ async function startServer(
     // tiny-csrf uses a specific cookie name and requires the secret to be set in cookieParser
     app.use(cookieParser(csrfSecret));
 
+    const weakDefaultSessionSecret = 'your-super-secret-session-key';
     let sessionSecret = getSecret('SESSION_SECRET');
     if (!sessionSecret) {
-        logger.error('❌ [FATAL] SESSION_SECRET is not set in environment variables.');
-        logger.error('   This is required for security in all environments. The application will now exit.');
-        process.exit(1);
+        if (process.env.NODE_ENV === 'production') {
+            logger.error('❌ [FATAL] SESSION_SECRET is not set in environment variables.');
+            logger.error('   This is required for security in production. The application will now exit.');
+            process.exit(1);
+        } else {
+            sessionSecret = weakDefaultSessionSecret;
+            logger.warn('⚠️ [SECURITY] SESSION_SECRET is not set. Using a default for development.');
+            logger.warn('   Do not use this configuration in production.');
+        }
     }
 
 


### PR DESCRIPTION
This PR resolves the issue where the server would crash immediately upon startup in a fresh development environment because `SESSION_SECRET` was not set.

Changes:
- Modified `server/server.js` to check `NODE_ENV`.
- If `NODE_ENV` is not `production` and `SESSION_SECRET` is missing, a default weak secret is used, and a warning is logged.
- If `NODE_ENV` is `production` and `SESSION_SECRET` is missing, the fatal error behavior is preserved.
- Updated `server/ENV_DOCUMENTATION.md` with clearer instructions.

Verified:
- Ran `npm start` in development mode (default): Server starts with a warning.
- Ran `NODE_ENV=production npm start`: Server crashes with a fatal error (as expected).

---
*PR created automatically by Jules for task [5267542036000045664](https://jules.google.com/task/5267542036000045664) started by @LokiMetaSmith*