### PR TITLE
Fix preview box resizing images to fit window

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,9 +177,10 @@
 
           <!-- Canvas for Image Editing -->
           <div class="bg-gray-50 p-4 rounded-lg shadow-inner mb-6">
-            <div class="relative w-fit mx-auto">
-              <canvas
-                id="imageCanvas"
+            <div class="overflow-auto max-h-[600px] max-w-full">
+              <div class="relative w-fit mx-auto">
+                <canvas
+                  id="imageCanvas"
                 width="500"
                 height="400"
                 class="block border-2 border-dashed border-gray-300 rounded-md bg-white"
@@ -229,6 +230,7 @@
                 Keep important elements 2-3mm from edge!
               </p>
             </div>
+          </div>
           </div>
 
           <!-- Basic Image Editing Controls -->

--- a/server.log
+++ b/server.log
@@ -1,0 +1,5 @@
+
+> lokimetasmith.github.io@1.0.0 start
+> serve dist
+
+sh: 1: serve: not found

--- a/src/index.js
+++ b/src/index.js
@@ -1153,6 +1153,10 @@ function setCanvasSize(logicalWidth, logicalHeight) {
   // Scale the context to account for the higher resolution.
   // Using setTransform ensures this is not cumulative.
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+  // Update CSS size to match logical size
+  canvas.style.width = `${logicalWidth}px`;
+  canvas.style.height = `${logicalHeight}px`;
 }
 
 // --- Image Loading and Editing Functions ---
@@ -1190,20 +1194,8 @@ function loadFileAsImage(file) {
         originalImage = img;
         updateEditingButtonsState(false);
         showPaymentStatus("Image loaded successfully.", "success");
-        const maxWidth = 500,
-          maxHeight = 400;
         let newWidth = img.width,
           newHeight = img.height;
-        if (newWidth > maxWidth) {
-          const r = maxWidth / newWidth;
-          newWidth = maxWidth;
-          newHeight *= r;
-        }
-        if (newHeight > maxHeight) {
-          const r = maxHeight / newHeight;
-          newHeight = maxHeight;
-          newWidth *= r;
-        }
         if (canvas && ctx) {
           setCanvasSize(newWidth, newHeight);
           ctx.clearRect(0, 0, newWidth, newHeight);
@@ -1534,20 +1526,8 @@ function handleResetImage() {
     currentPolygons = [];
     currentCutline = [];
 
-    const maxWidth = 500,
-      maxHeight = 400;
     let newWidth = originalImage.width,
       newHeight = originalImage.height;
-    if (newWidth > maxWidth) {
-      const r = maxWidth / newWidth;
-      newWidth = maxWidth;
-      newHeight *= r;
-    }
-    if (newHeight > maxHeight) {
-      const r = maxHeight / newHeight;
-      newHeight = maxHeight;
-      newWidth *= r;
-    }
 
     if (canvas && ctx) {
       setCanvasSize(newWidth, newHeight);
@@ -2084,20 +2064,8 @@ async function handleRemoteImageLoad(imageUrl) {
     updateEditingButtonsState(false); // Enable editing
 
     // Standard canvas init logic
-    const maxWidth = 500,
-      maxHeight = 400;
     let newWidth = img.width,
       newHeight = img.height;
-    if (newWidth > maxWidth) {
-      const r = maxWidth / newWidth;
-      newWidth = maxWidth;
-      newHeight *= r;
-    }
-    if (newHeight > maxHeight) {
-      const r = maxHeight / newHeight;
-      newHeight = maxHeight;
-      newWidth *= r;
-    }
     setCanvasSize(newWidth, newHeight);
     ctx.clearRect(0, 0, newWidth, newHeight);
     ctx.drawImage(originalImage, 0, 0, newWidth, newHeight);
@@ -2147,20 +2115,8 @@ async function loadProductForBuyer(productId) {
     img.onload = () => {
       originalImage = img;
       // Draw
-      const maxWidth = 500,
-        maxHeight = 400;
       let newWidth = img.width,
         newHeight = img.height;
-      if (newWidth > maxWidth) {
-        const r = maxWidth / newWidth;
-        newWidth = maxWidth;
-        newHeight *= r;
-      }
-      if (newHeight > maxHeight) {
-        const r = maxHeight / newHeight;
-        newHeight = maxHeight;
-        newWidth *= r;
-      }
       setCanvasSize(newWidth, newHeight);
       ctx.clearRect(0, 0, newWidth, newHeight);
       ctx.drawImage(originalImage, 0, 0, newWidth, newHeight);

--- a/vite.log
+++ b/vite.log
@@ -1,0 +1,35 @@
+
+> lokimetasmith.github.io@1.0.0 dev
+> vite
+
+
+  VITE v7.1.12  ready in 490 ms
+
+  ➜  Local:   http://localhost:5173/
+  ➜  Network: http://192.168.0.2:5173/
+9:18:09 PM [vite] (client) page reload src/index.js
+9:18:09 PM [vite] (client) hmr update /styles.css?direct
+9:18:13 PM [vite] (client) hmr update /styles.css?direct
+9:18:13 PM [vite] (client) hmr update /styles.css?direct
+9:18:54 PM [vite] (client) page reload src/index.js
+9:18:54 PM [vite] (client) hmr update /styles.css?direct
+9:18:59 PM [vite] (client) page reload src/index.js
+9:18:59 PM [vite] (client) hmr update /styles.css?direct
+9:19:09 PM [vite] (client) page reload src/index.js
+9:19:09 PM [vite] (client) hmr update /styles.css?direct
+9:19:14 PM [vite] (client) hmr update /styles.css?direct
+9:19:14 PM [vite] (client) hmr update /styles.css?direct
+9:19:57 PM [vite] (client) page reload src/index.js
+9:19:57 PM [vite] (client) hmr update /styles.css?direct
+9:20:42 PM [vite] (client) page reload src/index.js
+9:20:42 PM [vite] (client) hmr update /styles.css?direct
+9:21:04 PM [vite] (client) hmr update /styles.css?direct
+9:21:04 PM [vite] (client) hmr update /styles.css?direct
+9:21:28 PM [vite] (client) hmr update /styles.css?direct
+9:21:28 PM [vite] (client) hmr update /styles.css?direct
+9:21:32 PM [vite] (client) hmr update /styles.css?direct
+9:21:32 PM [vite] (client) hmr update /styles.css?direct
+9:21:44 PM [vite] (client) hmr update /styles.css?direct
+9:21:44 PM [vite] (client) hmr update /styles.css?direct
+9:22:01 PM [vite] (client) page reload src/index.js
+9:22:01 PM [vite] (client) hmr update /styles.css?direct


### PR DESCRIPTION
The preview box was resizing all images to fit within a 500x400 window, which distorted the preview for users who wanted to see the image at its true size. 

This change:
1.  Removes the scaling logic in `src/index.js` that forced images into the 500x400 box.
2.  Wraps the canvas in `index.html` with a scrollable container (`overflow-auto max-h-[600px]`), allowing larger images to be viewed by scrolling.
3.  Ensures `setCanvasSize` updates the canvas style dimensions to match the image's logical dimensions, preventing browser-side scaling.

Verified with a Playwright script that uploads a large image (2048x2048) and confirms the canvas dimensions are preserved and scrollbars are available (implicit via container size check). Existing E2E tests also passed.

---
*PR created automatically by Jules for task [967535247781433130](https://jules.google.com/task/967535247781433130) started by @LokiMetaSmith*