### PR TITLE
Add right-click paste support to canvas preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,7 +177,13 @@
 
           <!-- Canvas for Image Editing -->
           <div class="bg-gray-50 p-4 rounded-lg shadow-inner mb-6">
-            <div class="relative w-fit mx-auto">
+            <div
+              id="canvas-container"
+              class="relative w-fit mx-auto outline-none"
+              contenteditable="true"
+              inputmode="none"
+              style="caret-color: transparent;"
+            >
               <canvas
                 id="imageCanvas"
                 width="500"
@@ -191,6 +197,7 @@
                 class="absolute inset-0 flex flex-col items-center justify-center select-none z-20 bg-white/60 backdrop-blur-sm rounded-lg cursor-pointer hover:bg-white/80 transition-colors focus-visible:ring-4 focus-visible:ring-splotch-teal focus-visible:outline-none focus-visible:ring-inset"
                 role="button"
                 tabindex="0"
+                contenteditable="false"
                 aria-label="Upload an image by clicking or dragging and dropping"
               >
                 <svg
@@ -225,6 +232,7 @@
                 id="designMarginNote"
                 class="absolute bottom-2 right-2 text-xs text-splotch-red p-1 bg-white bg-opacity-75 rounded"
                 style="font-family: var(--font-baumans); display: none"
+                contenteditable="false"
               >
                 Keep important elements 2-3mm from edge!
               </p>

--- a/src/index.js
+++ b/src/index.js
@@ -480,15 +480,54 @@ async function BootStrap() {
 
   window.addEventListener("paste", (e) => {
     const items = (e.clipboardData || e.originalEvent.clipboardData).items;
+    let hasFile = false;
     for (const item of items) {
       if (item.kind === "file") {
         const file = item.getAsFile();
         if (file) {
           loadFileAsImage(file);
+          hasFile = true;
         }
       }
     }
+
+    if (hasFile) {
+      e.preventDefault();
+      return;
+    }
+
+    // Check if targeting canvas container
+    const container = document.getElementById("canvas-container");
+    if (container && (e.target === container || container.contains(e.target))) {
+      // If pasting text into canvas container, block it
+      e.preventDefault();
+    }
   });
+
+  // Block keys in canvas container to prevent text input
+  const container = document.getElementById("canvas-container");
+  if (container) {
+    container.addEventListener("keydown", (e) => {
+      // Allow shortcuts like Ctrl+C, Ctrl+V, Ctrl+X
+      if (e.ctrlKey || e.metaKey) return;
+
+      // Allow navigation arrows, Tab, Delete, and Backspace
+      if (
+        [
+          "ArrowUp",
+          "ArrowDown",
+          "ArrowLeft",
+          "ArrowRight",
+          "Tab",
+          "Delete",
+          "Backspace",
+        ].includes(e.key)
+      )
+        return;
+
+      e.preventDefault();
+    });
+  }
 
   // Set up the payment form
   console.log(


### PR DESCRIPTION
- Wrapped canvas in `#canvas-container` with `contenteditable="true"` and `inputmode="none"` in `index.html`.
- Updated `src/index.js` to handle paste events specifically for the container and block text insertion.
- Added keydown listener to block typing but allow navigation and delete keys.
- Verified changes with Playwright script.

---
*PR created automatically by Jules for task [6333684952291027248](https://jules.google.com/task/6333684952291027248) started by @LokiMetaSmith*