### PR TITLE
Fix resize error and NaN dimensions with Smart Cutline

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1291,7 +1291,7 @@ function redrawAll() {
 
   // Store the results globally
   currentCutline = cutline;
-  currentBounds = ClipperLib.JS.BoundsOfPaths(cutline);
+  currentBounds = getBoundsOfPaths(cutline);
 
   // --- VALIDATION ---
   // Ensure the bounds are valid before attempting to redraw the canvas
@@ -1357,7 +1357,7 @@ function handleSvgUpload(svgText) {
     currentPolygons = polygons;
     currentCutline = cutline;
     // Calculate the bounds of the final cutline for pricing and display
-    currentBounds = ClipperLib.JS.BoundsOfPaths(cutline);
+    currentBounds = getBoundsOfPaths(cutline);
 
     // Set canvas size based on the final cutline bounds
     canvas.width = currentBounds.right - currentBounds.left + 40; // Add padding
@@ -1402,6 +1402,38 @@ function generateCutLine(polygons, offset) {
   });
 
   return cutline;
+}
+
+function getBoundsOfPaths(paths) {
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  let hasPoints = false;
+
+  for (const poly of paths) {
+    for (const pt of poly) {
+      hasPoints = true;
+      // Handle both case conventions just in case (Clipper uses X/Y, we use x/y)
+      const x = pt.x !== undefined ? pt.x : pt.X;
+      const y = pt.y !== undefined ? pt.y : pt.Y;
+
+      if (x < minX) minX = x;
+      if (x > maxX) maxX = x;
+      if (y < minY) minY = y;
+      if (y > maxY) maxY = y;
+    }
+  }
+
+  if (!hasPoints) {
+    return { left: 0, top: 0, right: 0, bottom: 0, width: 0, height: 0 };
+  }
+
+  return {
+    left: minX,
+    top: minY,
+    right: maxX,
+    bottom: maxY,
+    width: maxX - minX,
+    height: maxY - minY,
+  };
 }
 
 function drawPolygonsToCanvas(
@@ -1648,7 +1680,7 @@ function handleResetImage() {
 function rotateCanvasContentFixedBounds(angleDegrees) {
   if (basePolygons.length > 0) {
     // SVG Vector Rotation
-    const bounds = ClipperLib.JS.BoundsOfPaths(currentPolygons);
+    const bounds = getBoundsOfPaths(currentPolygons);
     const centerX = bounds.left + (bounds.right - bounds.left) / 2;
     const centerY = bounds.top + (bounds.bottom - bounds.top) / 2;
     const angleRad = (angleDegrees * Math.PI) / 180;
@@ -1722,7 +1754,7 @@ function rotateCanvasContentFixedBounds(angleDegrees) {
         // Regenerate currentCutline from rotated poly
         const cutline = generateCutLine(rasterCutlinePoly, cutlineOffset);
         currentCutline = cutline;
-        currentBounds = ClipperLib.JS.BoundsOfPaths(cutline);
+        currentBounds = getBoundsOfPaths(cutline);
     } else {
         // Default bounds if no cutline
         currentBounds = {
@@ -1840,7 +1872,7 @@ function handleStandardResize(targetInches) {
 
   let currentMaxWidthPixels;
   if (basePolygons.length > 0) {
-    const bounds = ClipperLib.JS.BoundsOfPaths(basePolygons);
+    const bounds = getBoundsOfPaths(basePolygons);
     currentMaxWidthPixels = Math.max(bounds.width, bounds.height);
   } else {
     currentMaxWidthPixels = Math.max(originalImage.width, originalImage.height);
@@ -1907,7 +1939,7 @@ function handleStandardResize(targetInches) {
           // Regenerate currentCutline
           const cutline = generateCutLine(rasterCutlinePoly, cutlineOffset);
           currentCutline = cutline;
-          currentBounds = ClipperLib.JS.BoundsOfPaths(cutline);
+          currentBounds = getBoundsOfPaths(cutline);
       } else {
           // Update the bounds and cutline for the new raster size (Default Box)
           currentBounds = {
@@ -2027,7 +2059,7 @@ function handleGenerateCutline() {
       // Generate the cutline immediately
       const cutline = generateCutLine(rasterCutlinePoly, cutlineOffset);
       currentCutline = cutline;
-      currentBounds = ClipperLib.JS.BoundsOfPaths(cutline);
+      currentBounds = getBoundsOfPaths(cutline);
 
       // Redraw decorations (which will now include the cutline overlay)
       // Note: We are drawing on top of the existing canvas. Previous decorations might be baked in if not cleared,


### PR DESCRIPTION
Fixes a critical issue where resizing an image with a generated "Smart Cutline" would cause dimension calculations to fail (resulting in `NaN` width/height) and potentially crash the application with a "Coordinate outside allowed range" error from the Clipper library.

The root cause was that the bounding box object returned by the Clipper library did not include `width` and `height` properties, and strict coordinate case sensitivity (X/Y vs x/y) caused bounds calculation to fail for application-generated paths.

Changes:
- Added `getBoundsOfPaths` helper in `src/index.js` to correctly calculate bounds including width/height and handle coordinate case discrepancies.
- Replaced direct `ClipperLib.JS.BoundsOfPaths` calls with `getBoundsOfPaths` throughout `src/index.js`.
- Verified with reproduction test case.

---
*PR created automatically by Jules for task [6849693377060596685](https://jules.google.com/task/6849693377060596685) started by @LokiMetaSmith*