### PR TITLE
Fix TypeError in stalled order notification loop

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -134,7 +134,7 @@ async function main() {
   Last Update: ${new Date(order.lastUpdatedAt || order.receivedAt).toLocaleString()}
       `;
       try {
-        const sentMessage = await bot.sendMessage(getSecret('TELEGRAM_CHANNEL_ID'), message, {
+        const sentMessage = await bot.telegram.sendMessage(getSecret('TELEGRAM_CHANNEL_ID'), message, {
           reply_to_message_id: order.telegramMessageId,
         });
         // Store the message ID so we can delete it later


### PR DESCRIPTION
Fixed a `TypeError: bot.sendMessage is not a function` in `server/index.js` that occurred during the periodic check for stalled orders. The `Telegraf` library places API methods like `sendMessage` under the `.telegram` property, not directly on the bot instance. Changed the call to `bot.telegram.sendMessage`.

---
*PR created automatically by Jules for task [9050536472804639004](https://jules.google.com/task/9050536472804639004) started by @LokiMetaSmith*