### PR TITLE
Ensure mobile responsiveness and fix header overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@
         <!-- Sticker Design and Options Box -->
         <div
           id="sticker-design-box"
-          class="p-6 rounded-lg shadow-md border border-gray-200 bg-gray-50 mb-8 outline-none"
+          class="scroll-mt-32 p-6 rounded-lg shadow-md border border-gray-200 bg-gray-50 mb-8 outline-none"
           tabindex="-1"
         >
           <!-- UPLOAD STICKER FILE -->

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,4 +1,4 @@
-import { defineConfig } from '@playwright/test';
+import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   webServer: {
@@ -18,6 +18,20 @@ export default defineConfig({
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
   },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'Mobile Chrome',
+      use: { ...devices['Pixel 5'] },
+    },
+    {
+      name: 'Mobile Safari',
+      use: { ...devices['iPhone 12'] },
+    },
+  ],
   testDir: 'playwright_tests',
   reporter: 'list',
 });

--- a/playwright_tests/mobile-responsiveness.spec.js
+++ b/playwright_tests/mobile-responsiveness.spec.js
@@ -1,0 +1,135 @@
+import { test, expect } from './test-setup.js';
+
+test.describe('Mobile Responsiveness', () => {
+
+  test('Critical elements should be visible on mobile', async ({ page }) => {
+    await page.goto('/');
+
+    // Wait for the page to be ready
+    await page.waitForLoadState('domcontentloaded');
+
+    const jumpButton = page.locator('nav.top-menu-bar .menu-item').filter({ hasText: 'Jump to Sticker Editor' });
+    const orderHistoryButton = page.locator('nav.top-menu-bar .menu-item').filter({ hasText: 'View Order History' });
+
+    // The file input itself might be hidden or styled differently, but let's check it or its label
+    const fileInput = page.locator('#file');
+
+    const canvasContainer = page.locator('#canvas-container');
+    const editingControls = page.locator('#editing-controls');
+
+    // Payment form is visible initially? Or parts of it?
+    // It is in the DOM.
+    const paymentForm = page.locator('#payment-form');
+
+    await expect(jumpButton).toBeVisible();
+    await expect(orderHistoryButton).toBeVisible();
+    await expect(fileInput).toBeVisible();
+    await expect(canvasContainer).toBeVisible();
+    await expect(editingControls).toBeVisible();
+    await expect(paymentForm).toBeVisible();
+  });
+
+  test('Navigation buttons should not obscure critical controls', async ({ page, isMobile }) => {
+    // Only run this check on mobile viewports
+    // isMobile is true for mobile projects configured in playwright.config.js
+    if (!isMobile) test.skip();
+
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const jumpButton = page.locator('nav.top-menu-bar .menu-item').filter({ hasText: 'Jump to Sticker Editor' });
+    const fileInput = page.locator('#file');
+    const fileInputLabel = page.locator('label[for="file"]');
+
+    // Wait for elements to be stable
+    await jumpButton.waitFor();
+    await fileInput.waitFor();
+
+    // Check if the button covers the file input or label
+    // We can check bounding boxes
+    const buttonBox = await jumpButton.boundingBox();
+    const inputBox = await fileInput.boundingBox();
+    const labelBox = await fileInputLabel.boundingBox();
+
+    // Helper to check intersection
+    const intersects = (box1, box2) => {
+        if (!box1 || !box2) return false;
+        return !(box2.x >= box1.x + box1.width ||
+                 box2.x + box2.width <= box1.x ||
+                 box2.y >= box1.y + box1.height ||
+                 box2.y + box2.height <= box1.y);
+    };
+
+    // If they intersect, the test should fail
+    if (buttonBox && inputBox) {
+        const isOverlappingInput = intersects(buttonBox, inputBox);
+        expect(isOverlappingInput, `Jump to Sticker Editor button overlaps with file input. Button: ${JSON.stringify(buttonBox)}, Input: ${JSON.stringify(inputBox)}`).toBeFalsy();
+    }
+
+    if (buttonBox && labelBox) {
+        const isOverlappingLabel = intersects(buttonBox, labelBox);
+        expect(isOverlappingLabel, `Jump to Sticker Editor button overlaps with file input label. Button: ${JSON.stringify(buttonBox)}, Label: ${JSON.stringify(labelBox)}`).toBeFalsy();
+    }
+  });
+
+  test('Small mobile viewport (320px) overlap check', async ({ page }) => {
+    // Explicitly set a small viewport
+    await page.setViewportSize({ width: 320, height: 600 });
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const jumpButton = page.locator('nav.top-menu-bar .menu-item').filter({ hasText: 'Jump to Sticker Editor' });
+    const fileInput = page.locator('#file');
+
+    await jumpButton.waitFor();
+
+    const buttonBox = await jumpButton.boundingBox();
+    const inputBox = await fileInput.boundingBox();
+
+    const intersects = (box1, box2) => {
+        if (!box1 || !box2) return false;
+        return !(box2.x >= box1.x + box1.width ||
+                 box2.x + box2.width <= box1.x ||
+                 box2.y >= box1.y + box1.height ||
+                 box2.y + box2.height <= box1.y);
+    };
+
+    if (buttonBox && inputBox) {
+        const isOverlapping = intersects(buttonBox, inputBox);
+        expect(isOverlapping, `Jump to Sticker Editor button overlaps with file input on small screen. Button: ${JSON.stringify(buttonBox)}, Input: ${JSON.stringify(inputBox)}`).toBeFalsy();
+    }
+  });
+
+  test('Anchor navigation should not be obscured by fixed elements', async ({ page, isMobile }) => {
+    if (!isMobile) test.skip();
+
+    await page.goto('/');
+
+    const jumpButton = page.locator('nav.top-menu-bar .menu-item').filter({ hasText: 'Jump to Sticker Editor' });
+    const fileInput = page.locator('#file');
+
+    // Click the jump button to scroll to the element
+    await jumpButton.click();
+
+    // Wait for scroll (simple timeout or polling scroll position might be needed, but click usually triggers it)
+    await page.waitForTimeout(1000); // Give it time to scroll
+
+    const buttonBox = await jumpButton.boundingBox();
+    const inputBox = await fileInput.boundingBox();
+
+    const intersects = (box1, box2) => {
+        if (!box1 || !box2) return false;
+        return !(box2.x >= box1.x + box1.width ||
+                 box2.x + box2.width <= box1.x ||
+                 box2.y >= box1.y + box1.height ||
+                 box2.y + box2.height <= box1.y);
+    };
+
+    if (buttonBox && inputBox) {
+        const isOverlapping = intersects(buttonBox, inputBox);
+        // This is where we expect it might fail if scroll-margin-top is not set
+        expect(isOverlapping, `Jump to Sticker Editor button overlaps with file input after navigation. Button: ${JSON.stringify(buttonBox)}, Input: ${JSON.stringify(inputBox)}`).toBeFalsy();
+    }
+  });
+
+});


### PR DESCRIPTION
This PR improves mobile responsiveness testing and fixes a layout issue where the fixed top navigation bar would obscure the "Upload Sticker Design Image" section when navigating to it on mobile devices.

Changes:
- Configured Playwright to run tests on Mobile Chrome and Mobile Safari.
- Added a new test suite `playwright_tests/mobile-responsiveness.spec.js` that checks for visibility of key elements and verifies that the fixed header does not overlap with interactive elements like the file input.
- Added `scroll-mt-32` class to the `#sticker-design-box` container in `index.html` to ensure proper spacing when scrolling to the element.

---
*PR created automatically by Jules for task [9926176520936607742](https://jules.google.com/task/9926176520936607742) started by @LokiMetaSmith*