### PR TITLE
Fix login error toast visibility behind modal

### DIFF
--- a/printshop.html
+++ b/printshop.html
@@ -284,12 +284,12 @@
         <div class="animate-spin rounded-full h-32 w-32 border-t-2 border-b-2 border-blue-500"></div>
     </div>
 
-    <div id="error-toast" class="hidden fixed bottom-0 right-0 mb-4 mr-4 bg-red-500 text-white px-4 py-2 rounded-md shadow-md" role="alert" aria-live="assertive">
+    <div id="error-toast" class="hidden fixed bottom-0 right-0 mb-4 mr-4 bg-red-500 text-white px-4 py-2 rounded-md shadow-md z-[100]" role="alert" aria-live="assertive">
         <span id="error-message"></span>
         <button id="close-error-toast" class="ml-4 text-white font-bold" aria-label="Close error message">&times;</button>
     </div>
 
-    <div id="success-toast" class="hidden fixed bottom-0 right-0 mb-4 mr-4 bg-green-500 text-white px-4 py-2 rounded-md shadow-md" role="status" aria-live="polite">
+    <div id="success-toast" class="hidden fixed bottom-0 right-0 mb-4 mr-4 bg-green-500 text-white px-4 py-2 rounded-md shadow-md z-[100]" role="status" aria-live="polite">
         <span id="success-message"></span>
         <button id="close-success-toast" class="ml-4 text-white font-bold" aria-label="Close success message">&times;</button>
     </div>


### PR DESCRIPTION
Fixes an issue where the error toast notification for invalid login credentials was not visible because it was rendered behind the login modal. Added `z-[100]` to the toast elements in `printshop.html` to ensure they are stacked above the modal (which has `z-50`). Verified with a Playwright reproduction test and visual inspection.

---
*PR created automatically by Jules for task [15969586002574982522](https://jules.google.com/task/15969586002574982522) started by @LokiMetaSmith*