### PR TITLE
Fix traceContour failure on full-bleed opaque images

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -19,6 +19,7 @@ These issues represent the most severe risks to the application's functionality 
 -   **[x] Fix failing security tests due to missing test files:** The security tests `tests/security_xss.test.js` and `server/tests/security_mass_assignment.test.js` were failing because they relied on non-existent dummy files. They have been updated to dynamically create and clean up these files.
 -   **[x] Fix failing tracker tests:** The test `tests/tracker.test.js` was failing because the `EasyPost` mock was not being applied correctly due to module resolution issues between the root and server `node_modules`. This has been fixed by mocking the specific resolved path.
 -   **[x] Fix failing Telegram Bot unit tests:** The tests in `tests/telegram_bot.test.js` are failing with "next(ctx) called with invalid context" due to improper mocking of the `Telegraf` bot instance in the test environment.
+-   **[x] Fix regression in `traceContour`:** Fixed an issue where `traceContour` failed to detect full-bleed opaque images (or images matching the detected background color) by implementing a fallback retry mechanism without background color filtering.
 
 ---
 


### PR DESCRIPTION
This PR fixes a regression in the `traceContours` function where images that are fully opaque (full-bleed) and match the color of the corners (detected as background color) would result in no generated contours. 

The fix involves a two-pass approach:
1. Attempt to trace contours using the detected background color filtering.
2. If no contours are found, retry the trace without background color filtering (relying only on alpha transparency).

This ensures that full-bleed images are correctly traced while maintaining background removal for standard images.


---
*PR created automatically by Jules for task [11368149081268731428](https://jules.google.com/task/11368149081268731428) started by @LokiMetaSmith*