### PR TITLE
Fix canvas rotation shrinking on High-DPR displays

### DIFF
--- a/playwright_tests/regression_rotation_dpr.spec.js
+++ b/playwright_tests/regression_rotation_dpr.spec.js
@@ -1,0 +1,81 @@
+import { test, expect } from './test-setup.js';
+
+test.use({ deviceScaleFactor: 2 });
+
+test('verify rotation behavior with DPR=2', async ({ page }) => {
+  await page.goto('/');
+
+  // Generate a non-square image 300x200
+  const nonSquareImage = await page.evaluate(() => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 300;
+    canvas.height = 200;
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = 'red';
+    ctx.fillRect(0, 0, 300, 200);
+    return canvas.toDataURL('image/png');
+  });
+
+  const buffer = Buffer.from(nonSquareImage.split(',')[1], 'base64');
+
+  const fileChooserPromise = page.waitForEvent('filechooser');
+  // Wait for input to be present before clicking label
+  await page.waitForSelector('input[type="file"]');
+  await page.locator('label[for="file"]').click();
+  const fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles({
+    name: 'test-image.png',
+    mimeType: 'image/png',
+    buffer: buffer,
+  });
+
+  // Wait for processing
+  const rotateLeftBtn = page.locator('#rotateLeftBtn');
+  await expect(rotateLeftBtn).toBeEnabled({ timeout: 10000 });
+
+  // Get initial canvas size
+  const canvas = page.locator('#imageCanvas');
+
+  // Wait for canvas to settle (checking width is > 0)
+  await expect(async () => {
+     const w = await canvas.getAttribute('width');
+     expect(Number(w)).toBeGreaterThan(0);
+  }).toPass();
+
+  const initialWidth = await canvas.getAttribute('width');
+  const initialHeight = await canvas.getAttribute('height');
+  // Clean up style strings to get numbers (e.g. "600px" -> 600)
+  const initialStyleWidth = await canvas.evaluate(el => parseFloat(el.style.width));
+  const initialStyleHeight = await canvas.evaluate(el => parseFloat(el.style.height));
+
+  console.log('Initial Physical:', initialWidth, initialHeight);
+  console.log('Initial Logical (Style):', initialStyleWidth, initialStyleHeight);
+
+  // Rotate
+  await rotateLeftBtn.click();
+
+  // Wait for potential animation/repaint and state update
+  // We can wait for the width attribute to change if we expect it to change (swap)
+  // Since 300x200 != 200x300, it should change.
+  await expect(async () => {
+      const currentWidth = await canvas.getAttribute('width');
+      expect(currentWidth).not.toBe(initialWidth);
+  }).toPass();
+
+  // Get new canvas size
+  const newWidth = await canvas.getAttribute('width');
+  const newHeight = await canvas.getAttribute('height');
+  const newStyleWidth = await canvas.evaluate(el => parseFloat(el.style.width));
+  const newStyleHeight = await canvas.evaluate(el => parseFloat(el.style.height));
+
+  console.log('New Physical:', newWidth, newHeight);
+  console.log('New Logical (Style):', newStyleWidth, newStyleHeight);
+
+  // Assertions: Dimensions should be swapped exactly
+  expect(newWidth).toBe(initialHeight);
+  expect(newHeight).toBe(initialWidth);
+
+  // Check logical dimensions (allow small floating point differences if any, though likely exact)
+  expect(newStyleWidth).toBeCloseTo(initialStyleHeight, 1);
+  expect(newStyleHeight).toBeCloseTo(initialStyleWidth, 1);
+});


### PR DESCRIPTION
This change fixes a bug where rotating an image on a device with a high Device Pixel Ratio (DPR > 1) caused the image to shrink or display incorrectly. 

The issue was caused by `setCanvasSize` applying the DPR scale factor to dimensions that were already physical pixels. The fix involves:
1. Calculating logical dimensions by dividing physical dimensions by DPR.
2. Creating a temporary canvas with physical dimensions to preserve image quality.
3. Explicitly resetting the context transform (`ctx.setTransform(1, 0, 0, 1, 0, 0)`) before drawing the temporary canvas back onto the main canvas to prevent double scaling.

A regression test (`playwright_tests/regression_rotation_dpr.spec.js`) has been added to verify the fix.

---
*PR created automatically by Jules for task [595206139392262830](https://jules.google.com/task/595206139392262830) started by @LokiMetaSmith*