### PR TITLE
Update printshop.html footer copyright to 2026 Splotch Creative LLC

### DIFF
--- a/printshop.html
+++ b/printshop.html
@@ -276,7 +276,7 @@
 </div>
     <footer class="bg-white shadow-md mt-8">
         <div class="container mx-auto px-6 py-3 text-center text-gray-500">
-            &copy; 2025 Print Shop
+            &copy; 2026 Splotch Creative LLC
         </div>
     </footer>
 


### PR DESCRIPTION
Updated the footer copyright text in `printshop.html` to reflect the new company name and year "2026 Splotch Creative LLC", replacing the old "2025 Print Shop" text. Verified the change visually using a Playwright script.

---
*PR created automatically by Jules for task [17138955203581234346](https://jules.google.com/task/17138955203581234346) started by @LokiMetaSmith*