### PR TITLE
🎨 Palette: Add phone number input masking

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2026-02-13 - Font Preview in Select Dropdowns
 **Learning:** Adding `style="font-family: ..."` to `<option>` elements in a font selector is a low-effort, high-impact UX improvement that allows users to preview typefaces immediately without selecting them first.
 **Action:** When implementing font selection tools, always attempt to display the font name in its own typeface within the selection interface.
+
+## 2026-02-15 - Input Masking
+**Learning:** Simple input masking (like for phone numbers) significantly reduces cognitive load and formatting errors without requiring heavy libraries.
+**Action:** Implement lightweight masking for structured inputs whenever possible.

--- a/index.html
+++ b/index.html
@@ -87,6 +87,7 @@
     <script type="module" src="./src/index.js" defer></script>
     <script type="module" src="./src/mascot.js" defer></script>
     <script type="module" src="./src/a11y-improvements.js" defer></script>
+    <script type="module" src="./src/ux-enhancements.js" defer></script>
     <script src="/cookie-consent.js" defer></script>
     <link rel="manifest" href="/manifest.json" />
   </head>

--- a/src/ux-enhancements.js
+++ b/src/ux-enhancements.js
@@ -1,0 +1,38 @@
+/**
+ * Formats a raw phone number string into (XXX) XXX-XXXX format.
+ * @param {string} value - The raw input value.
+ * @returns {string} - The formatted phone number.
+ */
+export function formatPhoneNumber(value) {
+  if (!value) return value;
+  const phoneNumber = value.replace(/[^\d]/g, '');
+  const phoneNumberLength = phoneNumber.length;
+
+  if (phoneNumberLength < 4) return phoneNumber;
+  if (phoneNumberLength < 7) {
+    return `(${phoneNumber.slice(0, 3)}) ${phoneNumber.slice(3)}`;
+  }
+  return `(${phoneNumber.slice(0, 3)}) ${phoneNumber.slice(3, 6)}-${phoneNumber.slice(6, 10)}`;
+}
+
+/**
+ * Sets up phone number formatting for the #phone input field.
+ */
+export function setupPhoneFormatting() {
+  const phoneInput = document.getElementById('phone');
+  if (!phoneInput) return;
+
+  phoneInput.addEventListener('input', (e) => {
+    const formatted = formatPhoneNumber(e.target.value);
+    if (e.target.value !== formatted) {
+      e.target.value = formatted;
+    }
+  });
+}
+
+// Initialize on load
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', () => {
+    setupPhoneFormatting();
+  });
+}

--- a/tests/frontend/ux_enhancements.test.js
+++ b/tests/frontend/ux_enhancements.test.js
@@ -1,0 +1,33 @@
+import { formatPhoneNumber } from '../../src/ux-enhancements.js';
+
+describe('Phone Number Formatting', () => {
+  test('returns original value if empty', () => {
+    expect(formatPhoneNumber('')).toBe('');
+    expect(formatPhoneNumber(null)).toBe(null);
+  });
+
+  test('returns raw digits if length < 4', () => {
+    expect(formatPhoneNumber('1')).toBe('1');
+    expect(formatPhoneNumber('123')).toBe('123');
+  });
+
+  test('formats area code', () => {
+    expect(formatPhoneNumber('1234')).toBe('(123) 4');
+    expect(formatPhoneNumber('123456')).toBe('(123) 456');
+  });
+
+  test('formats full number', () => {
+    expect(formatPhoneNumber('1234567')).toBe('(123) 456-7');
+    expect(formatPhoneNumber('1234567890')).toBe('(123) 456-7890');
+  });
+
+  test('ignores extra digits beyond 10', () => {
+    // Current implementation drops characters after index 10
+    expect(formatPhoneNumber('12345678901')).toBe('(123) 456-7890');
+  });
+
+  test('handles non-numeric input', () => {
+    expect(formatPhoneNumber('a1b2c3')).toBe('123');
+    expect(formatPhoneNumber('(123) 456-7890')).toBe('(123) 456-7890');
+  });
+});


### PR DESCRIPTION
Implemented input masking for the phone number field in `index.html`. The input now automatically formats as `(XXX) XXX-XXXX` as the user types. This was verified with unit tests and a Playwright script. Also updated the Palette journal with learnings about input masking. Reverted an accessibility regression (aria-label on slider) identified during code review.

---
*PR created automatically by Jules for task [16287710426109059533](https://jules.google.com/task/16287710426109059533) started by @LokiMetaSmith*