### PR TITLE
Fix security prototype tests by handling WAF 403 responses

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -20,6 +20,7 @@ These issues represent the most severe risks to the application's functionality 
 -   **[x] Fix failing tracker tests:** The test `tests/tracker.test.js` was failing because the `EasyPost` mock was not being applied correctly due to module resolution issues between the root and server `node_modules`. This has been fixed by mocking the specific resolved path.
 -   **[x] Fix failing Telegram Bot unit tests:** The tests in `tests/telegram_bot.test.js` are failing with "next(ctx) called with invalid context" due to improper mocking of the `Telegraf` bot instance in the test environment.
 -   **[x] Fix regression in `traceContour`:** Fixed an issue where `traceContour` failed to detect full-bleed opaque images (or images matching the detected background color) by implementing a fallback retry mechanism without background color filtering (Fixed regression caused by closure capturing initial background color).
+-   **[x] Fix failing security prototype tests:** The tests `tests/security_prototype.test.js` were failing because the WAF was correctly blocking prototype pollution attempts with a 403 Forbidden response, but the test expected a 400 Bad Request from the controller validation. Updated tests to accept both.
 
 ---
 

--- a/tests/security_prototype.test.js
+++ b/tests/security_prototype.test.js
@@ -71,8 +71,13 @@ describe('Security: Prototype Pollution Prevention', () => {
             .get('/api/orders/__proto__')
             .set('Authorization', `Bearer ${token}`);
 
-        expect(res.statusCode).toBe(400);
-        expect(res.body.errors[0].msg).toBe('Invalid ID');
+        // Can be blocked by WAF (403) or caught by validation (400)
+        if (res.statusCode === 403) {
+             expect(res.body.error).toBe('Forbidden');
+        } else {
+             expect(res.statusCode).toBe(400);
+             expect(res.body.errors[0].msg).toBe('Invalid ID');
+        }
     });
 
     it('should block prototype pollution attempts on GET /api/orders/constructor', async () => {
@@ -120,8 +125,13 @@ describe('Security: Prototype Pollution Prevention', () => {
             .set('X-CSRF-Token', csrfToken)
             .send({ status: 'SHIPPED' });
 
-        expect(res.statusCode).toBe(400);
-        expect(res.body.errors[0].msg).toBe('Invalid ID');
+        // Can be blocked by WAF (403) or caught by validation (400)
+        if (res.statusCode === 403) {
+             expect(res.body.error).toBe('Forbidden');
+        } else {
+             expect(res.statusCode).toBe(400);
+             expect(res.body.errors[0].msg).toBe('Invalid ID');
+        }
     });
 
     it('should block prototype pollution attempts on POST /api/orders/:orderId/tracking', async () => {
@@ -149,7 +159,12 @@ describe('Security: Prototype Pollution Prevention', () => {
             .set('X-CSRF-Token', csrfToken)
             .send({ trackingNumber: '123', courier: 'UPS' });
 
-        expect(res.statusCode).toBe(400);
-        expect(res.body.errors[0].msg).toBe('Invalid ID');
+        // Can be blocked by WAF (403) or caught by validation (400)
+        if (res.statusCode === 403) {
+             expect(res.body.error).toBe('Forbidden');
+        } else {
+             expect(res.statusCode).toBe(400);
+             expect(res.body.errors[0].msg).toBe('Invalid ID');
+        }
     });
 });


### PR DESCRIPTION
Updated `tests/security_prototype.test.js` to accept `403` status code from WAF in addition to `400` status code from application validation for prototype pollution tests. This ensures the tests pass whether the request is blocked by the WAF or the controller validator.

Also updated `docs/todo.md` to reflect the completion of this task.

---
*PR created automatically by Jules for task [3211466243528385523](https://jules.google.com/task/3211466243528385523) started by @LokiMetaSmith*