### PR TITLE
🎨 Palette: Unified status badges in Order History

### DIFF
--- a/printshop.html
+++ b/printshop.html
@@ -47,13 +47,6 @@
         }
         .order-details dt { font-weight: bold; }
         .order-details dd { margin-left: 0; margin-bottom: 0.5em; }
-        .status-new { background-color: #3B82F6; color: white; }
-        .status-accepted { background-color: #F59E0B; color: white; }
-        .status-printing { background-color: #8B5CF6; color: white; }
-        .status-shipped { background-color: #10B981; color: white; }
-        .status-canceled { background-color: #EF4444; color: white; }
-        .status-delivered { background-color: #6366F1; color: white; }
-        .status-completed { background-color: #22C55E; color: white; }
         .filter-btn {
             background-color: #e2e8f0;
             color: #4a5568;

--- a/splotch-theme.css
+++ b/splotch-theme.css
@@ -428,3 +428,12 @@ main.container > div:first-of-type { /* Targets the first div child of main, usu
 	border-bottom: 0;
 	margin-bottom: -10px;
 }
+
+/* Status Badges */
+.status-new { background-color: #3B82F6 !important; color: white !important; }
+.status-accepted { background-color: #F59E0B !important; color: white !important; }
+.status-printing { background-color: #8B5CF6 !important; color: white !important; }
+.status-shipped { background-color: #10B981 !important; color: white !important; }
+.status-delivered { background-color: #6366F1 !important; color: white !important; }
+.status-completed { background-color: #22C55E !important; color: white !important; }
+.status-canceled { background-color: #EF4444 !important; color: white !important; }

--- a/src/orders.js
+++ b/src/orders.js
@@ -243,7 +243,9 @@ document.addEventListener("DOMContentLoaded", async () => {
                         <h3 class="text-lg font-semibold text-splotch-red">Order ID: <span class="font-mono text-sm">${order.orderId.substring(0, 8)}...</span></h3>
                         <p class="text-sm text-gray-600">Ordered on: ${receivedDate}</p>
                         <p class="text-sm text-gray-600">Amount: ${formattedAmount}</p>
-                        <p class="text-sm text-gray-600">Status: <span class="font-semibold">${order.status}</span></p>
+                        <p class="text-sm text-gray-600 flex items-center gap-2">
+                            Status: <span class="px-2 py-0.5 rounded-full text-xs font-bold status-${order.status.toLowerCase()}">${order.status}</span>
+                        </p>
                     </div>
                     <div class="mt-4 sm:mt-0 sm:ml-4 flex-shrink-0">
                         <img src="${order.designImagePath}" alt="Sticker Design" class="w-24 h-24 object-cover border rounded-md">


### PR DESCRIPTION
Unified the order status badge design between the Dashboard (printshop.html) and Order History (orders.html) pages.

Changes:
- Moved status color CSS classes from `printshop.html` inline styles to `splotch-theme.css` for global availability.
- Updated `src/orders.js` to render statuses as styled badges instead of plain text.
- Cleaned up redundant inline CSS in `printshop.html`.

This improves visual consistency and makes the order history easier to scan.

---
*PR created automatically by Jules for task [11080597409107675218](https://jules.google.com/task/11080597409107675218) started by @LokiMetaSmith*