### PR TITLE
🎨 Palette: Add "Clear" button to file input for easier reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,19 +155,32 @@
             <label class="label text-sm font-medium text-gray-700" for="file"
               >Upload Sticker Design Image:</label
             >
-            <div class="control">
-              <input
-                class="input mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100"
-                id="file"
-                name="file"
-                type="file"
-                accept="image/*"
-                aria-describedby="file-helper"
-              />
+            <div class="control flex items-center gap-2">
+              <div class="flex-grow">
+                <input
+                  class="input mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100"
+                  id="file"
+                  name="file"
+                  type="file"
+                  accept="image/*"
+                  aria-describedby="file-helper"
+                />
+              </div>
               <span
                 id="fileNameDisplay"
                 class="text-sm text-gray-600 ml-2"
               ></span>
+              <button
+                type="button"
+                id="clearFileBtn"
+                class="hidden text-splotch-red hover:text-red-700 p-2 rounded-full focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-splotch-red transition-colors"
+                aria-label="Clear selected file"
+                data-tooltip="Remove image and reset"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
             </div>
             <p
               id="file-helper"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@commitlint/config-conventional": "^19.8.1",
     "@eslint/js": "^9.39.2",
     "@faker-js/faker": "^8.4.1",
-    "@playwright/test": "^1.57.0",
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/cli": "^4.1.18",
     "@tailwindcss/postcss": "^4.1.14",
     "autoprefixer": "^10.4.23",

--- a/playwright_tests/ux_clear_button.spec.js
+++ b/playwright_tests/ux_clear_button.spec.js
@@ -1,0 +1,43 @@
+import { test, expect } from './test-setup.js';
+
+test('allows a user to clear the uploaded image', async ({ page }) => {
+  await page.goto('/');
+
+  // Verify Clear button is hidden initially
+  const clearBtn = page.locator('#clearFileBtn');
+  await expect(clearBtn).toBeHidden();
+
+  // Upload an image
+  const fileChooserPromise = page.waitForEvent('filechooser');
+  // We use the label because the input itself might be hidden or styled
+  await page.locator('label[for="file"]').click();
+  const fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles('public/mascot.png');
+
+  // Verify image loaded (wait for rotate button enabled)
+  await expect(page.locator('#rotateLeftBtn')).toBeEnabled({ timeout: 10000 });
+
+  // Verify Clear button is now visible
+  await expect(clearBtn).toBeVisible();
+
+  // Handle confirmation dialog
+  page.on('dialog', dialog => dialog.accept());
+
+  // Click Clear button
+  await clearBtn.click();
+
+  // Verify image is cleared:
+  // 1. Placeholder should be visible
+  await expect(page.locator('#canvas-placeholder')).toBeVisible();
+  // 2. Rotate button should be disabled (or have disabled class)
+  await expect(page.locator('#rotateLeftBtn')).toBeDisabled();
+  // 3. Clear button should be hidden again
+  await expect(clearBtn).toBeHidden();
+  // 4. File input value should be empty
+  const fileInput = page.locator('#file');
+  const value = await fileInput.inputValue();
+  expect(value).toBe('');
+  // 5. Filename display should be empty
+  const fileNameDisplay = page.locator('#fileNameDisplay');
+  await expect(fileNameDisplay).toHaveText('');
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,8 +121,8 @@ importers:
         specifier: ^8.4.1
         version: 8.4.1
       '@playwright/test':
-        specifier: ^1.57.0
-        version: 1.57.0
+        specifier: ^1.58.2
+        version: 1.58.2
       '@tailwindcss/cli':
         specifier: ^4.1.18
         version: 4.1.18
@@ -968,8 +968,8 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@playwright/test@1.57.0':
-    resolution: {integrity: sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==}
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3447,18 +3447,8 @@ packages:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
 
-  playwright-core@1.57.0:
-    resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   playwright-core@1.58.2:
     resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  playwright@1.57.0:
-    resolution: {integrity: sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5222,9 +5212,9 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@playwright/test@1.57.0':
+  '@playwright/test@1.58.2':
     dependencies:
-      playwright: 1.57.0
+      playwright: 1.58.2
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -7843,15 +7833,7 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
-  playwright-core@1.57.0: {}
-
   playwright-core@1.58.2: {}
-
-  playwright@1.57.0:
-    dependencies:
-      playwright-core: 1.57.0
-    optionalDependencies:
-      fsevents: 2.3.2
 
   playwright@1.58.2:
     dependencies:

--- a/src/index.js
+++ b/src/index.js
@@ -62,6 +62,7 @@ let paymentStatusContainer,
 let rotateLeftBtnEl,
   rotateRightBtnEl,
   resetBtnEl,
+  clearFileBtn,
   resizeInputEl,
   resizeBtnEl,
   grayscaleBtnEl,
@@ -171,6 +172,7 @@ async function BootStrap() {
   rotateLeftBtnEl = document.getElementById("rotateLeftBtn");
   rotateRightBtnEl = document.getElementById("rotateRightBtn");
   resetBtnEl = document.getElementById("resetBtn");
+  clearFileBtn = document.getElementById("clearFileBtn");
   const resizeSliderEl = document.getElementById("resizeSlider");
   const resizeInputNumberEl = document.getElementById("resizeInput");
   const resizeUnitLabelEl = document.getElementById("resizeUnitLabel");
@@ -272,6 +274,7 @@ async function BootStrap() {
       rotateCanvasContentFixedBounds(90),
     );
   if (resetBtnEl) resetBtnEl.addEventListener("click", handleResetImage);
+  if (clearFileBtn) clearFileBtn.addEventListener("click", handleClearImage);
   if (grayscaleBtnEl)
     grayscaleBtnEl.addEventListener("click", toggleGrayscaleFilter);
   if (sepiaBtnEl) sepiaBtnEl.addEventListener("click", toggleSepiaFilter);
@@ -1375,6 +1378,7 @@ function loadFileAsImage(file) {
       img.onload = () => {
         originalImage = img;
         updateEditingButtonsState(false);
+        if (clearFileBtn) clearFileBtn.classList.remove("hidden");
         showPaymentStatus("Image loaded successfully.", "success");
         let newWidth = img.width,
           newHeight = img.height;
@@ -1532,6 +1536,7 @@ function handleSvgUpload(svgText) {
     // Initial drawing
     redrawAll();
 
+    if (clearFileBtn) clearFileBtn.classList.remove("hidden");
     showPaymentStatus("SVG processed and cutline generated.", "success");
     updateEditingButtonsState(false); // Enable editing buttons
   } catch (error) {
@@ -1726,6 +1731,34 @@ function handleAddText() {
   ctx.textBaseline = "middle";
   ctx.fillText(text, canvas.width / 2, canvas.height / 2);
   showPaymentStatus(`Text "${text}" added.`, "success");
+}
+
+function handleClearImage() {
+  if (!confirm("Are you sure you want to remove the image?")) return;
+
+  originalImage = null;
+  basePolygons = [];
+  currentPolygons = [];
+  rasterCutlinePoly = null;
+  currentCutline = [];
+  currentBounds = null;
+  cleanCanvasState = null;
+
+  if (fileInputGlobalRef) fileInputGlobalRef.value = "";
+  if (fileNameDisplayEl) fileNameDisplayEl.textContent = "";
+
+  if (canvas && ctx) {
+    // Reset to default size (matches HTML)
+    setCanvasSize(500, 400);
+    // Clearing 0,0 to width,height works because setCanvasSize sets transform
+    ctx.clearRect(0, 0, 500, 400);
+  }
+
+  updateEditingButtonsState(true);
+  calculateAndUpdatePrice();
+
+  if (clearFileBtn) clearFileBtn.classList.add("hidden");
+  showPaymentStatus("Image removed.", "info");
 }
 
 function handleResetImage() {
@@ -2445,6 +2478,7 @@ async function handleRemoteImageLoad(imageUrl) {
 
     calculateAndUpdatePrice();
     drawCanvasDecorations(currentBounds);
+    if (clearFileBtn) clearFileBtn.classList.remove("hidden");
     showPaymentStatus("Design loaded! You can now adjust options.", "success");
   };
   img.onerror = () =>


### PR DESCRIPTION
Added a "Clear" button (trash/X icon) next to the file input that appears when an image is loaded. This allows users to easily remove the uploaded image and reset the editor to its initial state. Implemented `handleClearImage` logic in `src/index.js` to clear state variables and the canvas. Added an E2E test `playwright_tests/ux_clear_button.spec.js`. Updated `@playwright/test` to 1.58.2 to match the installed `playwright` version and fix test execution errors.

---
*PR created automatically by Jules for task [17167959468553755315](https://jules.google.com/task/17167959468553755315) started by @LokiMetaSmith*