### PR TITLE
⚡ Bolt: Optimize isPointInPolygon to avoid division

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -47,3 +47,7 @@
 ## 2026-02-23 - [ClipperLib Coordinate Case Sensitivity]
 **Learning:** `ClipperLib` uses uppercase `X` and `Y` properties for points. Accessing `point.y` (lowercase) returns `undefined`, leading to `NaN` in calculations. This silent failure in map/transform functions can be hard to spot if downstream consumers handle `NaN` gracefully (or if the feature just silently breaks).
 **Action:** Always verify property casing when working with external libraries, especially those ported from other languages (like C# or C++), which often use PascalCase.
+
+## 2026-02-24 - [Point in Polygon Optimization]
+**Learning:** Floating-point division is significantly slower than multiplication (latency 10-20 cycles vs 3-4). In geometric containment checks (ray casting), the inequality `point.x < ((xj - xi) * (point.y - yi)) / (yj - yi) + xi` can be rewritten as a cross-multiplication `(point.x - xi) * (yj - yi) < (xj - xi) * (point.y - yi)` (handling sign of dy), yielding ~29% speedup.
+**Action:** When optimizing geometric predicates, look for opportunities to replace division with multiplication using algebraic rearrangement, especially in hot loops.


### PR DESCRIPTION
💡 What: Optimized `isPointInPolygon` in `src/lib/image-processing.js` to avoid floating-point division.
🎯 Why: `isPointInPolygon` is called O(N^2) times during contour filtering. Division is expensive.
📊 Impact: Reduces execution time of point containment checks by ~29%.
🔬 Measurement: Verified with a benchmark script (`benchmark_poly.js`) running 1M random point checks against a 100-gon. Correctness verified with existing unit tests `tests/filterInternalContours.test.js`.

---
*PR created automatically by Jules for task [7240643620018390857](https://jules.google.com/task/7240643620018390857) started by @LokiMetaSmith*