### PR TITLE
🎨 Palette: Add keyboard shortcuts for image editor

### DIFF
--- a/src/ux-enhancements.js
+++ b/src/ux-enhancements.js
@@ -47,7 +47,8 @@ export function setupTooltips() {
 
   // Create the arrow element
   const arrow = document.createElement("div");
-  arrow.className = "absolute w-0 h-0 border-solid border-transparent pointer-events-none";
+  arrow.className =
+    "absolute w-0 h-0 border-solid border-transparent pointer-events-none";
   // Arrow size: 8px
   arrow.style.borderWidth = "8px";
   arrow.style.left = "50%";
@@ -67,9 +68,9 @@ export function setupTooltips() {
     // Check if we have a content span, if not create one
     let contentSpan = tooltip.querySelector(".tooltip-content");
     if (!contentSpan) {
-        contentSpan = document.createElement("span");
-        contentSpan.className = "tooltip-content";
-        tooltip.insertBefore(contentSpan, arrow);
+      contentSpan = document.createElement("span");
+      contentSpan.className = "tooltip-content";
+      tooltip.insertBefore(contentSpan, arrow);
     }
     contentSpan.textContent = el.dataset.tooltip;
 
@@ -98,19 +99,19 @@ export function setupTooltips() {
 
     // Update Arrow Orientation
     if (isFlipped) {
-        // Tooltip is BELOW. Arrow should be at TOP, pointing UP.
-        // Border-bottom color should be Navy.
-        arrow.style.top = "-16px"; // 2 * borderWidth
-        arrow.style.bottom = "auto";
-        arrow.style.borderBottomColor = "var(--splotch-navy)";
-        arrow.style.borderTopColor = "transparent";
+      // Tooltip is BELOW. Arrow should be at TOP, pointing UP.
+      // Border-bottom color should be Navy.
+      arrow.style.top = "-16px"; // 2 * borderWidth
+      arrow.style.bottom = "auto";
+      arrow.style.borderBottomColor = "var(--splotch-navy)";
+      arrow.style.borderTopColor = "transparent";
     } else {
-        // Tooltip is ABOVE. Arrow should be at BOTTOM, pointing DOWN.
-        // Border-top color should be Navy.
-        arrow.style.top = "auto";
-        arrow.style.bottom = "-16px"; // 2 * borderWidth
-        arrow.style.borderTopColor = "var(--splotch-navy)";
-        arrow.style.borderBottomColor = "transparent";
+      // Tooltip is ABOVE. Arrow should be at BOTTOM, pointing DOWN.
+      // Border-top color should be Navy.
+      arrow.style.top = "auto";
+      arrow.style.bottom = "-16px"; // 2 * borderWidth
+      arrow.style.borderTopColor = "var(--splotch-navy)";
+      arrow.style.borderBottomColor = "transparent";
     }
 
     tooltip.classList.remove("opacity-0");
@@ -129,10 +130,96 @@ export function setupTooltips() {
   });
 }
 
+let keydownListener = null;
+
+/**
+ * Sets up global keyboard shortcuts for the image editor.
+ */
+export function setupKeyboardShortcuts() {
+  if (keydownListener) {
+    document.removeEventListener("keydown", keydownListener);
+  }
+
+  // Add shortcuts to tooltips
+  const shortcuts = {
+    rotateLeftBtn: " ([)",
+    rotateRightBtn: " (])",
+    grayscaleBtn: " (g)",
+    sepiaBtn: " (s)",
+  };
+
+  for (const [id, key] of Object.entries(shortcuts)) {
+    const el = document.getElementById(id);
+    if (el && el.dataset.tooltip) {
+      el.dataset.tooltip += key;
+    }
+  }
+
+  keydownListener = (e) => {
+    // Ignore if typing in input
+    if (
+      e.target.tagName === "INPUT" ||
+      e.target.tagName === "TEXTAREA" ||
+      e.target.isContentEditable
+    )
+      return;
+
+    // Ignore if modifiers (except Shift for zoom)
+    if (e.ctrlKey || e.metaKey || e.altKey) return;
+
+    switch (e.key) {
+      case "[":
+        document.getElementById("rotateLeftBtn")?.click();
+        break;
+      case "]":
+        document.getElementById("rotateRightBtn")?.click();
+        break;
+      case "g":
+        document.getElementById("grayscaleBtn")?.click();
+        break;
+      case "s":
+        document.getElementById("sepiaBtn")?.click();
+        break;
+      case "ArrowUp":
+        if (e.shiftKey) {
+          e.preventDefault(); // Prevent scrolling
+          const slider = document.getElementById("resizeSlider");
+          if (slider && !slider.disabled) {
+            const step = parseFloat(slider.step) || 0.1;
+            const val = parseFloat(slider.value) || 0;
+            const max = parseFloat(slider.max) || 100;
+            if (val + step <= max) {
+              slider.value = (val + step).toFixed(1); // Keep precision
+              slider.dispatchEvent(new Event("input"));
+            }
+          }
+        }
+        break;
+      case "ArrowDown":
+        if (e.shiftKey) {
+          e.preventDefault(); // Prevent scrolling
+          const slider = document.getElementById("resizeSlider");
+          if (slider && !slider.disabled) {
+            const step = parseFloat(slider.step) || 0.1;
+            const val = parseFloat(slider.value) || 0;
+            const min = parseFloat(slider.min) || 0;
+            if (val - step >= min) {
+              slider.value = (val - step).toFixed(1); // Keep precision
+              slider.dispatchEvent(new Event("input"));
+            }
+          }
+        }
+        break;
+    }
+  };
+  document.addEventListener("keydown", keydownListener);
+}
+
 // Initialize on load
 if (typeof document !== "undefined") {
   document.addEventListener("DOMContentLoaded", () => {
     setupPhoneFormatting();
     setupTooltips();
+    setupKeyboardShortcuts();
   });
 }

--- a/tests/frontend/keyboard_shortcuts.test.js
+++ b/tests/frontend/keyboard_shortcuts.test.js
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals';
+import { setupKeyboardShortcuts } from '../../src/ux-enhancements.js';
+
+describe('Keyboard Shortcuts', () => {
+    let rotateLeftSpy, rotateRightSpy, grayscaleSpy, sepiaSpy, sliderInputSpy;
+
+    beforeEach(() => {
+        // Reset DOM
+        document.body.innerHTML = `
+            <button id="rotateLeftBtn" data-tooltip="Rotate Left"></button>
+            <button id="rotateRightBtn" data-tooltip="Rotate Right"></button>
+            <button id="grayscaleBtn" data-tooltip="Grayscale"></button>
+            <button id="sepiaBtn" data-tooltip="Sepia"></button>
+            <input type="range" id="resizeSlider" value="3.0" step="0.1" />
+            <input type="text" id="textInput" />
+            <textarea id="textArea"></textarea>
+        `;
+
+        // Initialize shortcuts (assuming idempotent or handled)
+        setupKeyboardShortcuts();
+
+        // Spy on click methods
+        const leftBtn = document.getElementById('rotateLeftBtn');
+        const rightBtn = document.getElementById('rotateRightBtn');
+        const grayBtn = document.getElementById('grayscaleBtn');
+        const sepiaBtn = document.getElementById('sepiaBtn');
+        const slider = document.getElementById('resizeSlider');
+
+        rotateLeftSpy = jest.spyOn(leftBtn, 'click');
+        rotateRightSpy = jest.spyOn(rightBtn, 'click');
+        grayscaleSpy = jest.spyOn(grayBtn, 'click');
+        sepiaSpy = jest.spyOn(sepiaBtn, 'click');
+
+        // Mock slider dispatchEvent
+        sliderInputSpy = jest.fn();
+        slider.dispatchEvent = sliderInputSpy;
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('activates rotate left on [', () => {
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: '[' }));
+        expect(rotateLeftSpy).toHaveBeenCalled();
+    });
+
+    test('activates rotate right on ]', () => {
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: ']' }));
+        expect(rotateRightSpy).toHaveBeenCalled();
+    });
+
+    test('activates grayscale on g', () => {
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'g' }));
+        expect(grayscaleSpy).toHaveBeenCalled();
+    });
+
+    test('activates sepia on s', () => {
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 's' }));
+        expect(sepiaSpy).toHaveBeenCalled();
+    });
+
+    test('increases slider on Shift+ArrowUp', () => {
+        const slider = document.getElementById('resizeSlider');
+        const event = new KeyboardEvent('keydown', { key: 'ArrowUp', shiftKey: true });
+        document.dispatchEvent(event);
+
+        expect(parseFloat(slider.value)).toBeCloseTo(3.1);
+        expect(sliderInputSpy).toHaveBeenCalled();
+    });
+
+    test('decreases slider on Shift+ArrowDown', () => {
+        const slider = document.getElementById('resizeSlider');
+        const event = new KeyboardEvent('keydown', { key: 'ArrowDown', shiftKey: true });
+        document.dispatchEvent(event);
+
+        expect(parseFloat(slider.value)).toBeCloseTo(2.9);
+        expect(sliderInputSpy).toHaveBeenCalled();
+    });
+
+    test('ignores shortcuts when typing in input', () => {
+        const input = document.getElementById('textInput');
+        input.focus();
+        // Dispatch event on input element to simulate typing
+        input.dispatchEvent(new KeyboardEvent('keydown', { key: '[', bubbles: true }));
+
+        expect(rotateLeftSpy).not.toHaveBeenCalled();
+    });
+
+    test('ignores shortcuts when typing in textarea', () => {
+        const textarea = document.getElementById('textArea');
+        textarea.focus();
+        textarea.dispatchEvent(new KeyboardEvent('keydown', { key: ']', bubbles: true }));
+
+        expect(rotateRightSpy).not.toHaveBeenCalled();
+    });
+
+    test('updates tooltips with shortcuts', () => {
+        const leftBtn = document.getElementById('rotateLeftBtn');
+        expect(leftBtn.dataset.tooltip).toContain('[');
+
+        const rightBtn = document.getElementById('rotateRightBtn');
+        expect(rightBtn.dataset.tooltip).toContain(']');
+    });
+});


### PR DESCRIPTION
This PR adds keyboard shortcuts to the image editor to improve accessibility and workflow speed. It supports rotation, filters, and resizing via keyboard. Tooltips are updated to display the available shortcuts.

---
*PR created automatically by Jules for task [17740746626942735282](https://jules.google.com/task/17740746626942735282) started by @LokiMetaSmith*