### PR TITLE
🛡️ Sentinel: [HIGH] Fix Stored XSS via Uploads CSP

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -628,6 +628,14 @@ async function startServer(
             }
         }
     }));
+    // SECURITY: Enforce strict CSP for uploaded files to prevent Stored XSS
+    // This sandbox directive prevents script execution even if an attacker uploads a malicious SVG/HTML file
+    // that bypasses other checks.
+    app.use('/uploads', (req, res, next) => {
+        res.setHeader('Content-Security-Policy', "default-src 'none'; style-src 'unsafe-inline'; sandbox");
+        next();
+    });
+
     app.use('/uploads', express.static(path.join(__dirname, 'uploads'), {
         maxAge: '1d'
     }));

--- a/server/tests/security_uploads_csp.test.js
+++ b/server/tests/security_uploads_csp.test.js
@@ -1,0 +1,85 @@
+import { describe, beforeAll, afterAll, it, expect, jest } from '@jest/globals';
+import request from 'supertest';
+import { startServer } from '../server.js';
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+import { LowDbAdapter } from '../database/lowdb_adapter.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Helper to wait for server to start
+const waitFor = (ms) => new Promise(r => setTimeout(r, ms));
+
+describe('Security: Uploads CSP', () => {
+  let app;
+  let serverInstance;
+  let timers;
+  let bot;
+  const testDbPath = path.join(__dirname, 'test-db-uploads-csp.json');
+  const uploadsDir = path.join(__dirname, '../uploads');
+  const testFileName = 'test-csp.svg';
+  const testFile = path.join(uploadsDir, testFileName);
+
+  beforeAll(async () => {
+    // Ensure uploads directory exists
+    if (!fs.existsSync(uploadsDir)) {
+      fs.mkdirSync(uploadsDir, { recursive: true });
+    }
+    // Create a dummy SVG file
+    fs.writeFileSync(testFile, '<svg xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="40" /></svg>');
+
+    // Mock DB (minimal)
+    const mockLowDb = {
+        data: { orders: {}, users: {}, credentials: {}, config: {}, products: {}, emailIndex: {} },
+        write: async () => {},
+        read: async () => {}
+    };
+    const db = new LowDbAdapter(mockLowDb);
+
+    const mockSendEmail = jest.fn();
+    const mockSquareClient = {
+        locations: {},
+        payments: {}
+    };
+
+    // Start server
+    const server = await startServer(db, null, mockSendEmail, testDbPath, mockSquareClient);
+    app = server.app;
+    timers = server.timers;
+    bot = server.bot;
+    // We don't need app.listen() for supertest usually, but startServer returns app.
+    // However, cleanup might need closing something?
+    // startServer returns { app, timers, bot }
+  });
+
+  afterAll(async () => {
+    // Cleanup
+    if (fs.existsSync(testFile)) {
+      fs.unlinkSync(testFile);
+    }
+    if (bot) await bot.stop('test');
+    if (timers) timers.forEach(timer => clearInterval(timer));
+    // serverInstance is not used here because supertest takes 'app'
+  });
+
+  it('should serve uploaded files with strict CSP header', async () => {
+    const res = await request(app).get(`/uploads/${testFileName}`);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('image/svg+xml');
+
+    // Check for Strict CSP
+    const csp = res.headers['content-security-policy'];
+    expect(csp).toBeDefined();
+
+    // We expect 'sandbox' to be present to prevent script execution
+    expect(csp).toContain('sandbox');
+    // We expect 'default-src \'none\'' to block everything else by default
+    expect(csp).toContain("default-src 'none'");
+
+    // Ensure X-Content-Type-Options is nosniff
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+  });
+});


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Stored XSS via Uploads

🚨 Severity: HIGH
💡 Vulnerability: Uploaded files (like SVGs) were served with a lenient CSP that allowed script execution from 'self'. This could allow an attacker to upload a malicious SVG containing scripts and execute them in the context of the application (Stored XSS).
🎯 Impact: Attackers could execute arbitrary JavaScript in the victim's browser, potentially stealing session tokens or performing actions on their behalf.
🔧 Fix: Implemented a strict Content-Security-Policy middleware for the `/uploads` route. The policy `default-src 'none'; style-src 'unsafe-inline'; sandbox` ensures that scripts cannot execute, even if the file is navigated to directly.
✅ Verification: Added `server/tests/security_uploads_csp.test.js` which confirms the presence of the strict CSP headers. Ran all server tests to ensure no regressions.

---
*PR created automatically by Jules for task [15583659668486759891](https://jules.google.com/task/15583659668486759891) started by @LokiMetaSmith*