### PR TITLE
🎨 Palette: Add keyboard shortcuts cheat sheet modal

### DIFF
--- a/src/ux-enhancements.js
+++ b/src/ux-enhancements.js
@@ -215,11 +215,127 @@ export function setupKeyboardShortcuts() {
   document.addEventListener("keydown", keydownListener);
 }
 
+/**
+ * Creates and injects a "Keyboard Shortcuts" help modal and button.
+ */
+export function setupShortcutsHelp() {
+  const sellBtn = document.getElementById("sellDesignBtn");
+  const container = sellBtn ? sellBtn.parentNode : null;
+  if (!container) return; // Only run on pages with the header structure
+
+  // Prevent duplicate button
+  if (document.getElementById("shortcutsBtn")) return;
+
+  // Create the Help Button
+  const btn = document.createElement("button");
+  btn.id = "shortcutsBtn";
+  btn.type = "button";
+  btn.className =
+    "bg-gray-200 hover:bg-gray-300 text-gray-700 p-2 rounded-full focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 transition-colors";
+  btn.setAttribute("aria-label", "Show Keyboard Shortcuts");
+  btn.setAttribute("title", "Keyboard Shortcuts");
+  btn.innerHTML = `
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z" />
+    </svg>
+  `;
+  container.appendChild(btn);
+
+  // Create the Modal
+  const modal = document.createElement("div");
+  modal.id = "shortcutsModal";
+  modal.className =
+    "fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 hidden transition-opacity duration-200";
+  modal.setAttribute("role", "dialog");
+  modal.setAttribute("aria-modal", "true");
+  modal.setAttribute("aria-labelledby", "shortcutsModalTitle");
+
+  modal.innerHTML = `
+    <div class="bg-white rounded-lg shadow-xl p-6 w-full max-w-sm mx-4 transform transition-all scale-100" style="font-family: var(--font-baumans)">
+      <div class="flex justify-between items-center mb-4 border-b pb-2">
+        <h2 id="shortcutsModalTitle" class="text-xl font-bold text-splotch-navy">Keyboard Shortcuts</h2>
+        <button type="button" class="close-modal text-gray-400 hover:text-gray-600 focus:outline-none">
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
+        </button>
+      </div>
+
+      <div class="space-y-3">
+        <div class="flex justify-between items-center">
+          <span class="text-gray-700 font-medium">Rotate Left</span>
+          <kbd class="px-2 py-1 bg-gray-100 border border-gray-300 rounded-md text-sm font-mono text-gray-600 shadow-sm">[</kbd>
+        </div>
+        <div class="flex justify-between items-center">
+          <span class="text-gray-700 font-medium">Rotate Right</span>
+          <kbd class="px-2 py-1 bg-gray-100 border border-gray-300 rounded-md text-sm font-mono text-gray-600 shadow-sm">]</kbd>
+        </div>
+        <div class="flex justify-between items-center">
+          <span class="text-gray-700 font-medium">Grayscale Toggle</span>
+          <kbd class="px-2 py-1 bg-gray-100 border border-gray-300 rounded-md text-sm font-mono text-gray-600 shadow-sm">G</kbd>
+        </div>
+        <div class="flex justify-between items-center">
+          <span class="text-gray-700 font-medium">Sepia Toggle</span>
+          <kbd class="px-2 py-1 bg-gray-100 border border-gray-300 rounded-md text-sm font-mono text-gray-600 shadow-sm">S</kbd>
+        </div>
+        <div class="flex justify-between items-center">
+          <span class="text-gray-700 font-medium">Fine Tune Size</span>
+          <div class="flex gap-1">
+            <kbd class="px-2 py-1 bg-gray-100 border border-gray-300 rounded-md text-sm font-mono text-gray-600 shadow-sm">Shift</kbd>
+            <span class="self-center text-gray-400">+</span>
+            <kbd class="px-2 py-1 bg-gray-100 border border-gray-300 rounded-md text-sm font-mono text-gray-600 shadow-sm">↑/↓</kbd>
+          </div>
+        </div>
+      </div>
+
+      <div class="mt-6 text-center">
+        <button type="button" class="close-modal-btn bg-splotch-navy text-white hover:brightness-110 font-bold py-2 px-6 rounded-full shadow-md transition duration-150 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-splotch-navy">
+          Got it!
+        </button>
+      </div>
+    </div>
+  `;
+  document.body.appendChild(modal);
+
+  // Logic to Open/Close
+  const openModal = () => {
+    modal.classList.remove("hidden");
+    // Trap focus inside modal? (Simple version: focus close button)
+    setTimeout(() => {
+      modal.querySelector(".close-modal-btn").focus();
+    }, 100);
+  };
+
+  const closeModal = () => {
+    modal.classList.add("hidden");
+    btn.focus(); // Return focus to trigger button
+  };
+
+  btn.addEventListener("click", openModal);
+
+  // Close on button clicks
+  const closeButtons = modal.querySelectorAll(".close-modal, .close-modal-btn");
+  closeButtons.forEach((b) => b.addEventListener("click", closeModal));
+
+  // Close on click outside
+  modal.addEventListener("click", (e) => {
+    if (e.target === modal) {
+      closeModal();
+    }
+  });
+
+  // Close on Escape
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && !modal.classList.contains("hidden")) {
+      closeModal();
+    }
+  });
+}
+
 // Initialize on load
 if (typeof document !== "undefined") {
   document.addEventListener("DOMContentLoaded", () => {
     setupPhoneFormatting();
     setupTooltips();
     setupKeyboardShortcuts();
+    setupShortcutsHelp();
   });
 }

--- a/tests/frontend/keyboard_shortcuts_help.test.js
+++ b/tests/frontend/keyboard_shortcuts_help.test.js
@@ -1,0 +1,104 @@
+/**
+ * @jest-environment jsdom
+ */
+import { setupShortcutsHelp } from '../../src/ux-enhancements.js';
+
+describe('Keyboard Shortcuts Help Modal', () => {
+  let container;
+
+  beforeEach(() => {
+    // Set up the DOM structure required by the function
+    document.body.innerHTML = `
+      <div class="flex justify-between items-center">
+        <div class="flex space-x-2">
+           <button id="sellDesignBtn">Sell this Design</button>
+        </div>
+      </div>
+    `;
+    container = document.getElementById('sellDesignBtn').parentNode;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('injects the help button into the header', () => {
+    setupShortcutsHelp();
+    const btn = document.getElementById('shortcutsBtn');
+    expect(btn).not.toBeNull();
+    expect(container.contains(btn)).toBe(true);
+  });
+
+  test('does not duplicate the button if called twice', () => {
+    setupShortcutsHelp();
+    setupShortcutsHelp();
+    const btns = document.querySelectorAll('#shortcutsBtn');
+    expect(btns.length).toBe(1);
+  });
+
+  test('creates the modal in the body', () => {
+    setupShortcutsHelp();
+    const modal = document.getElementById('shortcutsModal');
+    expect(modal).not.toBeNull();
+    expect(document.body.contains(modal)).toBe(true);
+    expect(modal.classList.contains('hidden')).toBe(true);
+  });
+
+  test('opens the modal when button is clicked', () => {
+    setupShortcutsHelp();
+    const btn = document.getElementById('shortcutsBtn');
+    const modal = document.getElementById('shortcutsModal');
+
+    btn.click();
+    expect(modal.classList.contains('hidden')).toBe(false);
+  });
+
+  test('closes the modal when close button is clicked', () => {
+    setupShortcutsHelp();
+    const btn = document.getElementById('shortcutsBtn');
+    const modal = document.getElementById('shortcutsModal');
+
+    // Open it first
+    btn.click();
+    expect(modal.classList.contains('hidden')).toBe(false);
+
+    // Find close button (x)
+    const closeX = modal.querySelector('.close-modal');
+    closeX.click();
+    expect(modal.classList.contains('hidden')).toBe(true);
+  });
+
+  test('closes the modal when "Got it!" button is clicked', () => {
+    setupShortcutsHelp();
+    const btn = document.getElementById('shortcutsBtn');
+    const modal = document.getElementById('shortcutsModal');
+
+    btn.click();
+    const closeBtn = modal.querySelector('.close-modal-btn');
+    closeBtn.click();
+    expect(modal.classList.contains('hidden')).toBe(true);
+  });
+
+  test('closes the modal when clicking outside', () => {
+    setupShortcutsHelp();
+    const btn = document.getElementById('shortcutsBtn');
+    const modal = document.getElementById('shortcutsModal');
+
+    btn.click();
+    modal.click(); // Clicking the background
+    expect(modal.classList.contains('hidden')).toBe(true);
+  });
+
+  test('closes the modal when pressing Escape', () => {
+    setupShortcutsHelp();
+    const btn = document.getElementById('shortcutsBtn');
+    const modal = document.getElementById('shortcutsModal');
+
+    btn.click();
+
+    const event = new KeyboardEvent('keydown', { key: 'Escape' });
+    document.dispatchEvent(event);
+
+    expect(modal.classList.contains('hidden')).toBe(true);
+  });
+});


### PR DESCRIPTION
💡 What: Added a help modal listing keyboard shortcuts (`[`, `]`, `G`, `S`, `Shift+↑/↓`).
🎯 Why: To improve discoverability of power user features and accessibility.
📸 Visual: Modal appears when clicking the '?' icon in the header.
♿ Accessibility: Uses ARIA dialog roles and keyboard-accessible close controls.
🛠️ Implementation: Injected via `src/ux-enhancements.js` to keep `index.html` clean. Validated with unit tests.

---
*PR created automatically by Jules for task [12124002702331482510](https://jules.google.com/task/12124002702331482510) started by @LokiMetaSmith*