### PR TITLE
Fix timeouts in security integration tests

### DIFF
--- a/tests/security_input_validation.test.js
+++ b/tests/security_input_validation.test.js
@@ -21,6 +21,8 @@ describe('Security Input Validation', () => {
     let mockSquareClient;
 
     beforeAll(async () => {
+        process.env.NO_REDIS = 'true'; // Skip Redis check
+
         if (fs.existsSync(testDbPath)) fs.unlinkSync(testDbPath);
 
         db = await JSONFilePreset(testDbPath, { orders: {}, users: {}, credentials: {}, config: {} });
@@ -61,7 +63,7 @@ describe('Security Input Validation', () => {
         app = server.app;
         timers = server.timers;
         serverInstance = app.listen();
-    });
+    }, 120000); // Increase timeout to 120s
 
     beforeEach(async () => {
         db.data.orders = {};

--- a/tests/security_xss.test.js
+++ b/tests/security_xss.test.js
@@ -24,6 +24,8 @@ describe('Stored XSS Vulnerability Check (Order Details)', () => {
     let mockSendEmail;
 
     beforeAll(async () => {
+        process.env.NO_REDIS = 'true'; // Skip Redis check
+
         // Ensure clean DB start
         if (fs.existsSync(testDbPath)) {
             fs.unlinkSync(testDbPath);
@@ -86,7 +88,7 @@ describe('Stored XSS Vulnerability Check (Order Details)', () => {
         app = server.app;
         timers = server.timers;
         serverInstance = app.listen();
-    });
+    }, 120000); // Increase timeout to 120s
 
     beforeEach(async () => {
         db.data.orders = {};


### PR DESCRIPTION
Fixed timeouts in `tests/security_xss.test.js` and `tests/security_input_validation.test.js` by increasing the `beforeAll` timeout to 120s and explicitly disabling Redis checks to avoid connection delays and potential flakiness during server startup in the test environment.

---
*PR created automatically by Jules for task [236212537371311293](https://jules.google.com/task/236212537371311293) started by @LokiMetaSmith*