### PR TITLE
Deployment: Add DNS/Env guide and helper scripts

### DIFF
--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -35,4 +35,9 @@ There are four primary ways to deploy this application, each with its own guide:
 - **Use Case:** General information about using a reverse proxy (Caddy, Nginx) for security and SSL.
 - **📚 [Guide: Using a Reverse Proxy](./reverse-proxy.md)**
 
+### 7. DNS & Environments
+
+- **Use Case:** Setting up multiple environments (Production, Development) and configuring DNS.
+- **📚 [Guide: DNS & Environments](./dns-and-environments.md)**
+
 Please choose the guide that matches your deployment target.

--- a/docs/deployment/dns-and-environments.md
+++ b/docs/deployment/dns-and-environments.md
@@ -1,0 +1,133 @@
+# DNS & Environment Management Guide
+
+This guide details how to configure your DNS and reverse proxy to support multiple environments (e.g., **Production** and **Development**) on a single server or across multiple servers.
+
+## 1. DNS Strategy: Subdomains
+
+The standard best practice for separating environments is to use **subdomains**. This allows you to host different versions of your application on the same domain but with distinct prefixes.
+
+### Structure
+*   **Production:** `example.com` (or `www.example.com`)
+*   **Development:** `dev.example.com` (or `staging.example.com`)
+
+### DNS Records (A Records)
+You need to point both domain names to your server's public IP address.
+
+| Type | Name | Content / Value | TTL |
+| :--- | :--- | :--- | :--- |
+| A | `@` (root) | `203.0.113.10` (Your Server IP) | 3600 |
+| A | `dev` | `203.0.113.10` (Your Server IP) | 3600 |
+
+*   **`@`**: Points the root domain (`example.com`) to your server.
+*   **`dev`**: Points the subdomain (`dev.example.com`) to the **same** server IP.
+
+## 2. Reverse Proxy Configuration
+
+Your reverse proxy (Nginx or Caddy) listens on ports 80 and 443. It inspects the incoming request's "Host" header (`example.com` vs. `dev.example.com`) and routes traffic to the correct internal container.
+
+### Option A: Nginx (Traditional & Robust)
+
+You will need two separate `server` blocks in your Nginx configuration.
+
+**Production Block (`example.com` -> `app-prod:3000`):**
+```nginx
+server {
+    listen 80;
+    server_name example.com www.example.com;
+
+    location / {
+        proxy_pass http://app-prod:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+**Development Block (`dev.example.com` -> `app-dev:3001`):**
+```nginx
+server {
+    listen 80;
+    server_name dev.example.com;
+
+    location / {
+        proxy_pass http://app-dev:3001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+### Option B: Caddy (Automatic HTTPS)
+
+Caddy handles this much more simply. It automatically provisions SSL certificates for every domain block you define.
+
+**Caddyfile:**
+```caddy
+example.com {
+    reverse_proxy app-prod:3000
+}
+
+dev.example.com {
+    reverse_proxy app-dev:3001
+}
+```
+
+## 3. Docker Compose Setup
+
+To run two instances of the application on the same server, you need to define them as separate services in your `docker-compose.yml`.
+
+**Example `docker-compose.yml`:**
+
+```yaml
+version: '3.8'
+
+services:
+  # PRODUCTION INSTANCE
+  app-prod:
+    image: ghcr.io/lokimetasmith/print-shop:latest
+    container_name: print-shop-prod
+    restart: always
+    environment:
+      - NODE_ENV=production
+      - PORT=3000
+    # No ports mapping needed if using a reverse proxy in the same network
+    networks:
+      - web-net
+
+  # DEVELOPMENT INSTANCE
+  app-dev:
+    image: ghcr.io/lokimetasmith/print-shop:dev
+    container_name: print-shop-dev
+    restart: always
+    environment:
+      - NODE_ENV=development
+      - PORT=3001 # Internal port can be different, or same if containerized
+    networks:
+      - web-net
+
+  # REVERSE PROXY (Nginx or Caddy)
+  reverse-proxy:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf
+    depends_on:
+      - app-prod
+      - app-dev
+    networks:
+      - web-net
+
+networks:
+  web-net:
+```
+
+## 4. Automation Scripts
+
+We provide helper scripts to make this easier:
+
+*   **`scripts/update-dns-record.sh`**: Quickly adds an A record for a subdomain using the DigitalOcean CLI (`doctl`).
+*   **`scripts/generate-nginx-config.sh`**: Generates a valid Nginx server block for a new subdomain.
+
+See the `scripts/` directory for usage instructions.

--- a/scripts/generate-nginx-config.sh
+++ b/scripts/generate-nginx-config.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Generates an Nginx Server Block configuration
+
+echo "------------------------------------------------------------------"
+echo "Nginx Server Block Generator"
+echo "------------------------------------------------------------------"
+
+echo "This script generates an Nginx configuration file for a new subdomain."
+echo "You can paste the output into your nginx.conf or a new file in /etc/nginx/sites-available/."
+echo ""
+
+read -p "Enter the external domain (e.g., dev.example.com): " DOMAIN_NAME
+if [ -z "$DOMAIN_NAME" ]; then
+    echo "Domain cannot be empty."
+    exit 1
+fi
+
+read -p "Enter the internal backend address (e.g., app-dev:3000 or localhost:3001): " BACKEND_ADDR
+if [ -z "$BACKEND_ADDR" ]; then
+    echo "Backend address cannot be empty."
+    exit 1
+fi
+
+echo ""
+echo "--- COPY BELOW ---"
+echo ""
+
+cat <<EOF
+server {
+    listen 80;
+    server_name $DOMAIN_NAME;
+
+    # Basic security headers
+    add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-XSS-Protection "1; mode=block";
+    add_header X-Content-Type-Options "nosniff";
+
+    location / {
+        proxy_pass http://$BACKEND_ADDR;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+        proxy_cache_bypass \$http_upgrade;
+    }
+}
+EOF
+
+echo ""
+echo "--- END COPY ---"
+echo ""
+echo "Instructions:"
+echo "1. Copy the block above into your Nginx configuration."
+echo "2. Run 'nginx -t' to verify syntax."
+echo "3. Run 'nginx -s reload' to apply changes."
+echo "4. Use Certbot or similar to enable HTTPS: certbot --nginx -d $DOMAIN_NAME"

--- a/scripts/update-dns-record.sh
+++ b/scripts/update-dns-record.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Utility to add a DNS A record using DigitalOcean CLI (doctl)
+
+echo "------------------------------------------------------------------"
+echo "DNS A Record Update Tool (DigitalOcean)"
+echo "------------------------------------------------------------------"
+
+if ! command -v doctl &> /dev/null; then
+    echo "Error: 'doctl' is not installed or not in your PATH."
+    echo ""
+    echo "This script requires the DigitalOcean CLI to automate DNS updates."
+    echo "Please install it: https://docs.digitalocean.com/reference/doctl/how-to/install/"
+    echo ""
+    echo "Alternatively, you can manually add the record in your DNS provider's dashboard:"
+    echo "  Type: A"
+    echo "  Name: <subdomain> (e.g., 'dev')"
+    echo "  Value: <your-server-ip>"
+    exit 1
+fi
+
+echo "This script will add an 'A' record to your domain."
+echo ""
+
+read -p "Enter your root domain (e.g., example.com): " DOMAIN
+if [ -z "$DOMAIN" ]; then
+    echo "Domain cannot be empty."
+    exit 1
+fi
+
+read -p "Enter the record name/subdomain (e.g., 'dev' or '@' for root): " RECORD_NAME
+if [ -z "$RECORD_NAME" ]; then
+    echo "Record name cannot be empty."
+    exit 1
+fi
+
+read -p "Enter the IP address (e.g., 203.0.113.10): " IP_ADDRESS
+if [ -z "$IP_ADDRESS" ]; then
+    echo "IP address cannot be empty."
+    exit 1
+fi
+
+echo ""
+echo "Adding A record: $RECORD_NAME.$DOMAIN -> $IP_ADDRESS"
+echo "Running: doctl compute domain records create $DOMAIN --record-type A --record-name $RECORD_NAME --record-data $IP_ADDRESS"
+echo ""
+
+read -p "Are you sure? (y/n): " CONFIRM
+if [[ "$CONFIRM" != "y" ]]; then
+    echo "Operation cancelled."
+    exit 0
+fi
+
+doctl compute domain records create "$DOMAIN" --record-type A --record-name "$RECORD_NAME" --record-data "$IP_ADDRESS"
+
+if [ $? -eq 0 ]; then
+    echo ""
+    echo "Success! DNS record added."
+    echo "Note: DNS propagation may take some time."
+else
+    echo ""
+    echo "Failed to add DNS record. Please check your inputs and doctl authentication."
+fi


### PR DESCRIPTION
This PR adds comprehensive documentation and tooling for managing multiple deployment environments (e.g., Production and Development) on a single infrastructure.

**Documentation:**
- New guide: `docs/deployment/dns-and-environments.md`.
    - Explains DNS strategy using subdomains (`dev.example.com`).
    - Provides configuration examples for Nginx and Caddy reverse proxies.
    - Includes a `docker-compose.yml` example for running side-by-side environments.

**Tooling:**
- `scripts/update-dns-record.sh`: A bash script to quickly add A records using `doctl`. It handles error checking and provides manual instructions if the CLI tool is missing.
- `scripts/generate-nginx-config.sh`: A bash script that interactively generates a production-ready Nginx server block for a given subdomain and backend address.

These additions streamline the process of spinning up new development environments and configuring the necessary routing and DNS settings.

---
*PR created automatically by Jules for task [4559178373591420286](https://jules.google.com/task/4559178373591420286) started by @LokiMetaSmith*