### PR TITLE
🎨 Palette: [Add ARIA label & focus style to modal close button]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,6 @@
 ## 2026-02-27 - Focus Management on Hiding Elements
 **Learning:** Hiding an element that currently has focus (e.g., via `display: none` or `.hidden` class) resets focus to the `body`, disrupting keyboard navigation and forcing users to tab from the beginning of the document.
 **Action:** Always programmatically move focus to a logical next interactive element (e.g., an input or adjacent button) immediately after hiding the active element.
+## 2025-02-28 - Missing `aria-label`s on Dynamically Generated Icon-Only Close Buttons
+**Learning:** Icon-only close buttons (like the `&times;` or SVG cross) inside dynamically generated JavaScript modals are frequently overlooked when applying `aria-label`s and focus states (`focus-visible:ring-2`), creating accessibility barriers for screen-reader users and keyboard navigators.
+**Action:** When creating or reviewing UI components rendered via string templates in JavaScript, proactively verify that any icon-only buttons include an explicit `aria-label` describing the action, and feature distinct `focus-visible` styles for keyboard navigation.

--- a/src/ux-enhancements.js
+++ b/src/ux-enhancements.js
@@ -254,7 +254,7 @@ export function setupShortcutsHelp() {
     <div class="bg-white rounded-lg shadow-xl p-6 w-full max-w-sm mx-4 transform transition-all scale-100" style="font-family: var(--font-baumans)">
       <div class="flex justify-between items-center mb-4 border-b pb-2">
         <h2 id="shortcutsModalTitle" class="text-xl font-bold text-splotch-navy">Keyboard Shortcuts</h2>
-        <button type="button" class="close-modal text-gray-400 hover:text-gray-600 focus:outline-none">
+        <button type="button" class="close-modal text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-splotch-navy rounded" aria-label="Close shortcuts modal">
           <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
         </button>
       </div>


### PR DESCRIPTION
**🎨 Palette: [Add ARIA label & focus style to modal close button]**

💡 **What:** Added an explicit `aria-label` ("Close shortcuts modal") and Tailwind CSS `focus-visible` utility classes (`focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-splotch-navy rounded`) to the icon-only close button in the Keyboard Shortcuts modal (`src/ux-enhancements.js`).
🎯 **Why:** To improve accessibility. Icon-only buttons without labels are difficult or impossible for screen reader users to understand. Missing focus outlines make it challenging for keyboard users to navigate the modal interface.
📸 **Before/After:** (Visual change only affects keyboard focus state, presenting a clear navy ring outline).
♿ **Accessibility:** Fixes WCAG AA issues related to missing accessible names for controls and missing visible focus indicators.

---
*PR created automatically by Jules for task [10266382683128660266](https://jules.google.com/task/10266382683128660266) started by @LokiMetaSmith*