### PR TITLE
docs: add best practices for secure deployment to DigitalOcean

### DIFF
--- a/docs/deployment/remote-vps.md
+++ b/docs/deployment/remote-vps.md
@@ -184,6 +184,31 @@ DigitalOcean will now create the server. On its first boot, it will automaticall
 After these steps, your application will be live and running in a containerized environment.
 
 ---
+---
+
+## Best Practices for Secure Deployment & Team Access
+
+When deploying to a remote VPS like DigitalOcean in a production environment, especially for a team, it is highly recommended to adopt advanced deployment strategies and strict security measures.
+
+### Deployment Strategies & Secure Key Management
+
+*   **Infrastructure as Code (Terraform)**: For production and team environments, manage your Droplets using Infrastructure as Code (IaC) tools like Terraform. Define your infrastructure as code to manage Droplets, allowing you to define SSH keys via `digitalocean_ssh_key` resource and reference them in `digitalocean_droplet` without hardcoding keys in scripts.
+*   **DigitalOcean Team SSH Keys**: Add public keys to your DigitalOcean account/team rather than individual droplets. This allows new droplets to automatically include necessary keys at creation, keeping access centralized and secure.
+*   **CI/CD Pipeline Integration (GitLab CI/GitHub Actions)**: Use GitHub Actions or similar tools to build and deploy. Store the private SSH key securely in the CI/CD's secret management system (e.g., GitHub Secrets), allowing the pipeline to deploy without any developer needing to hold the key.
+*   **Secure Access via SSH Keys**: Prefer SSH key-based authentication exclusively, disabling root passwords in `/etc/ssh/sshd_config` for better security.
+
+### Developer-Agnostic Workflow
+
+*   **Use GitOps**: All infrastructure changes are handled via pull requests, making deployment steps transparent and consistent, removing dependency on specific machines.
+*   **API-Driven Provisioning**: Use the DigitalOcean API to trigger deployment actions, ensuring the process is automated and not reliant on a specific user's terminal.
+
+### Additional Best Practices
+
+*   **Firewall Configuration**: Create a Cloud Firewall to restrict access to authorized IP addresses (e.g., CI/CD IPs) and block unused ports.
+*   **Immutable Infrastructure**: Rebuild droplets from images rather than updating in-place to ensure consistency and reproducible environments.
+*   **2FA & Team Access**: Enable Two-Factor Authentication (2FA) for all team members in your DigitalOcean account to prevent unauthorized access.
+
+---
 
 ## Method 3: Manual Deployment (Legacy)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -17,10 +17,13 @@ This document outlines security best practices for this project, covering the we
     *   Enable detailed logging for the web server and operating system.
     *   Regularly monitor logs for suspicious activity.
     *   Use a centralized logging solution to aggregate and analyze logs.
-*   **Access Control:**
-    *   Use SSH keys for authentication instead of passwords.
-    *   Disable password-based authentication for SSH.
-    *   Limit SSH access to a small number of trusted IP addresses.
+*   **Access Control & Deployment Best Practices:**
+    *   **SSH Keys**: Use SSH keys for authentication instead of passwords. Add public keys to your cloud provider team account (e.g., DigitalOcean Team SSH Keys) for centralized access control.
+    *   **Disable Password Auth**: Disable password-based authentication for SSH by modifying `/etc/ssh/sshd_config`.
+    *   **CI/CD Integration**: Store private SSH keys securely in CI/CD secret management systems (e.g., GitHub Secrets, Vault) to allow developer-agnostic deployments without exposing keys manually.
+    *   **Firewalls**: Use Cloud Firewalls to restrict SSH access to a small number of trusted IP addresses and CI/CD server ranges.
+    *   **Two-Factor Authentication (2FA)**: Mandate 2FA for all team members accessing the infrastructure control plane (e.g., DigitalOcean account).
+    *   For a detailed guide on advanced production deployments, GitOps, and Terraform, see [Best Practices for Secure Deployment](deployment/remote-vps.md#best-practices-for-secure-deployment--team-access).
 
 ## Domain Name Security
 

--- a/scripts/deploy-digitalocean.sh
+++ b/scripts/deploy-digitalocean.sh
@@ -8,6 +8,11 @@
 # This script automates the creation of a new DigitalOcean Droplet and
 # provisions it to run the Print Shop application using a cloud-config file.
 #
+# NOTE: For production environments, larger teams, and scalable setups, it is
+# highly recommended to use Infrastructure-as-Code (IaC) tools like Terraform
+# and automated CI/CD pipelines instead of manual deploy scripts. See
+# docs/deployment/remote-vps.md for Best Practices on Secure Deployment.
+#
 # Prerequisites:
 # 1. doctl (DigitalOcean Command-Line Tool) must be installed and authenticated.
 #    - Installation: https://docs.digitalocean.com/reference/doctl/how-to/install/


### PR DESCRIPTION
This PR updates the DigitalOcean deployment documentation and security guidelines to strongly recommend advanced deployment strategies for production and team environments.

Specifically, it covers:
- Using Infrastructure as Code (Terraform) to manage Droplets and team SSH keys without hardcoding them.
- Centralizing SSH key access via DigitalOcean team keys instead of per-droplet keys.
- Leveraging CI/CD pipelines (e.g., GitHub Actions) with secret management for developer-agnostic deployments.
- Recommending GitOps workflows for transparent infrastructure changes.
- Disabling SSH password authentication in favor of keys.
- Applying cloud firewalls to restrict access to trusted/CI IPs.
- Promoting immutable infrastructure (rebuilding from images instead of in-place updates) and mandating 2FA for team members.
- Adding a comment to the manual `scripts/deploy-digitalocean.sh` script to advise using IaC/CI/CD for production.

---
*PR created automatically by Jules for task [9816894685453060432](https://jules.google.com/task/9816894685453060432) started by @LokiMetaSmith*