### PR TITLE
feat(ux): add confirmation dialog for canceling orders

### DIFF
--- a/UX_TODO.md
+++ b/UX_TODO.md
@@ -5,5 +5,5 @@ This is a list of proposed UX improvements for the Print Shop interface, ordered
 - [x] **Improve Focus States:** Add visible focus rings (e.g., `focus-visible:ring-2`) to interactive elements like buttons and inputs for better keyboard accessibility.
 - [ ] **Loading Spinners for Buttons:** Add inline loading spinners (or disable states) to action buttons (e.g., "Login", "Register", "Nest Stickers") to provide immediate visual feedback during async operations, replacing or supplementing the full-screen loader.
 - [ ] **Enhanced Empty States:** Replace generic "Loading orders..." or "Please log in" text in the orders list with a more visually distinct and helpful empty state design.
-- [ ] **Confirmation Modals for Destructive Actions:** Add a confirmation step (e.g., a native `confirm()` or a custom modal) before performing irreversible actions like changing an order status to "Canceled".
+- [x] **Confirmation Modals for Destructive Actions:** Add a confirmation step (e.g., a native `confirm()` or a custom modal) before performing irreversible actions like changing an order status to "Canceled".
 - [ ] **ARIA Attributes and Tooltips:** Ensure all icon-only buttons (like modal close buttons) have proper `aria-label` attributes and consider adding hover/focus tooltips for small utility buttons to clarify their purpose.

--- a/src/printshop.js
+++ b/src/printshop.js
@@ -637,6 +637,14 @@ function handleOrderListClick(e) {
     if (actionBtn) {
         const orderId = actionBtn.dataset.orderId;
         const status = actionBtn.dataset.status;
+
+        if (status === 'CANCELED') {
+            const confirmed = window.confirm('Are you sure you want to cancel this order? This action cannot be undone.');
+            if (!confirmed) {
+                return;
+            }
+        }
+
         updateOrderStatus(orderId, status);
         return;
     }


### PR DESCRIPTION
This PR addresses the UX_TODO item to add a confirmation step before destructive actions.

- Added a `window.confirm` dialog in `src/printshop.js` specifically when changing an order's status to `CANCELED`.
- If the user declines the confirmation, the status update is aborted.
- Checked off the corresponding item in `UX_TODO.md`.
- Wrote and ran a Playwright script locally to visually verify the dialog behavior and confirmed that unit tests pass.

---
*PR created automatically by Jules for task [3239107830852121065](https://jules.google.com/task/3239107830852121065) started by @LokiMetaSmith*