### PR TITLE
🎨 Palette: Add keyboard focus states to interactive buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
         <div class="flex space-x-2">
           <button
             id="sellDesignBtn"
-            class="bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded-full hidden"
+            class="bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded-full hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-green-600"
           >
             Sell this Design
           </button>
@@ -394,7 +394,7 @@
               id="grayscaleBtn"
               data-tooltip="Apply Grayscale Filter"
               aria-pressed="false"
-              class="lg:hidden xl:block"
+              class="lg:hidden xl:block focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-splotch-navy rounded"
             >
               Grayscale
             </button>
@@ -403,7 +403,7 @@
               id="sepiaBtn"
               data-tooltip="Apply Sepia Filter"
               aria-pressed="false"
-              class="lg:hidden xl:block"
+              class="lg:hidden xl:block focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-splotch-red rounded"
             >
               Sepia
             </button>
@@ -457,7 +457,7 @@
             <button
               type="button"
               id="generateCutlineBtn"
-              class="bg-teal-500 text-white col-span-2 sm:col-span-3 md:col-span-4 lg:col-span-4 xl:col-span-2 flex justify-center items-center gap-2"
+              class="bg-teal-500 text-white col-span-2 sm:col-span-3 md:col-span-4 lg:col-span-4 xl:col-span-2 flex justify-center items-center gap-2 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-teal-500"
               data-tooltip="Generate Cutline from Image Alpha"
             >
               Generate Smart Cutline
@@ -597,7 +597,7 @@
               <button
                 type="button"
                 id="addTextBtn"
-                class="bg-splotch-red hover:brightness-110 text-white font-semibold py-2.5 px-4 rounded-full shadow-md transition duration-150 ease-in-out transform hover:scale-105 self-end"
+                class="bg-splotch-red hover:brightness-110 text-white font-semibold py-2.5 px-4 rounded-full shadow-md transition duration-150 ease-in-out transform hover:scale-105 self-end focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-splotch-red"
                 style="
                   font-family: var(--font-baumans);
                   text-transform: uppercase;
@@ -1116,7 +1116,7 @@
               />
               <button
                 id="copyLinkBtn"
-                class="ml-2 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+                class="ml-2 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
               >
                 Copy
               </button>


### PR DESCRIPTION
### 💡 What: The UX enhancement added
Added explicit `focus-visible` Tailwind utility classes (e.g., `focus-visible:ring-2`, `focus-visible:ring-offset-2`) to several interactive buttons in `index.html` that previously lacked clear keyboard focus indicators.

### 🎯 Why: The user problem it solves
Users navigating the application via keyboard could easily lose track of their current focus position because some buttons had customized styles or lacked the default browser focus ring. This makes the interface more accessible and easier to navigate for screen-reader and keyboard-only users.

### ♿ Accessibility: Any a11y improvements made
Ensures compliance with WCAG 2.1 Success Criterion 2.4.7 (Focus Visible) by providing a highly visible focus indicator on interactive elements, specifically using `focus-visible` so that mouse users do not see the ring on click, maintaining visual polish while drastically improving keyboard navigation.

---
*PR created automatically by Jules for task [11953460062328998269](https://jules.google.com/task/11953460062328998269) started by @LokiMetaSmith*