### PR TITLE
Fix design margin note overlapping artwork

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,8 +177,19 @@
                 aria-label="Clear selected file"
                 data-tooltip="Remove image and reset"
               >
-                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke-width="1.5"
+                  stroke="currentColor"
+                  class="w-6 h-6"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M6 18L18 6M6 6l12 12"
+                  />
                 </svg>
               </button>
             </div>
@@ -249,15 +260,16 @@
                   (Tip: Drag the mascot here to try it!)
                 </p>
               </div>
-              <p
-                id="designMarginNote"
-                class="absolute bottom-2 right-2 text-xs text-splotch-red p-1 bg-white bg-opacity-75 rounded"
-                style="font-family: var(--font-baumans); display: none"
-                contenteditable="false"
-              >
-                Keep important elements 2-3mm from edge!
-              </p>
             </div>
+
+            <p
+              id="designMarginNote"
+              class="text-xs text-splotch-red bg-white border border-red-200 rounded-full shadow-sm px-3 py-1.5 mx-auto mt-4 w-fit"
+              style="font-family: var(--font-baumans); display: none"
+              contenteditable="false"
+            >
+              Keep important elements 2-3mm from edge!
+            </p>
           </div>
 
           <!-- Basic Image Editing Controls -->

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,21 @@
+1. **Understand the Goal**: The user wants to convert the plain text note "Keep important elements 2-3mm from edge!" into a "bubble text" style that does not occlude the artwork. Currently, it's a `<p>` tag positioned `absolute bottom-2 right-2` inside the `canvas-container`.
+2. **Current Implementation**:
+   - `index.html` has:
+     ```html
+     <p
+       id="designMarginNote"
+       class="absolute bottom-2 right-2 text-xs text-splotch-red p-1 bg-white bg-opacity-75 rounded"
+       style="font-family: var(--font-baumans); display: none"
+       contenteditable="false"
+     >
+       Keep important elements 2-3mm from edge!
+     </p>
+     ```
+3. **Proposed Changes**:
+   - To make it a "bubble text", we can change its styling in `index.html`. We can use a combination of padding, border-radius, background color, text color, and perhaps a small triangle (using `::after` or a small SVG) pointing towards the image, or simply styling it as a floating pill/bubble.
+   - To prevent it from occluding the artwork, we can move it *outside* the canvas (e.g., just below it), or position it in a way that it floats outside the bounding box of the canvas, but since the canvas container is `relative w-fit mx-auto`, placing it absolutely *outside* (e.g., `bottom: -30px`) might be better. Or we can just put it below the canvas container in the normal flow.
+   - Wait, if it's currently inside `#canvas-container`, it overlaps the canvas. If we move it outside the absolute positioning to be a block below the canvas, it won't occlude the artwork.
+   - Let's look at the image provided by the user: The text is right below the image bounding box, stylized as a red pill/bubble with a green circle drawn around it by the user. In the user's screenshot, it looks like it's currently a text floating *over* the bottom part of the canvas (occluding the dashed red cutline). The user says "make this a bubble text that doesn't occlude the artwork".
+   - So I should:
+     1. Move the `p#designMarginNote` outside of the `canvas` overlap.
+     2. Style it to look like a bubble.


### PR DESCRIPTION
Moved the design margin note out of the canvas container and styled it as a bubble to prevent overlapping uploaded artwork.

---
*PR created automatically by Jules for task [8840792331539409724](https://jules.google.com/task/8840792331539409724) started by @LokiMetaSmith*