### PR TITLE
fix: restore field name prefix to uploaded files

### DIFF
--- a/server/storage.js
+++ b/server/storage.js
@@ -56,7 +56,7 @@ export class LocalStorageProvider extends StorageProvider {
                 cb(null, this.uploadDir);
             },
             filename: (req, file, cb) => {
-                cb(null, randomUUID() + path.extname(file.originalname));
+                cb(null, file.fieldname + '-' + randomUUID() + path.extname(file.originalname));
             }
         });
     }
@@ -146,7 +146,7 @@ export class S3StorageProvider extends StorageProvider {
                 cb(null, this.tempDir);
             },
             filename: (req, file, cb) => {
-                cb(null, randomUUID() + path.extname(file.originalname));
+                cb(null, file.fieldname + '-' + randomUUID() + path.extname(file.originalname));
             }
         });
     }


### PR DESCRIPTION
When using `multer` for uploads, the resulting files were missing their field name prefixes (e.g., `designImage-`, `cutLineFile-`), causing them to only appear as random UUIDs (e.g., `123-abc.png`). This change ensures that the original field names are correctly prepended to the filenames upon save (e.g., `designImage-123-abc.png`) in both local and S3 storage implementations. This makes it easier to track which file is which and fixes an issue where the temporary files were being tracked by git due to not matching the ignore rules.

---
*PR created automatically by Jules for task [13593477251917180301](https://jules.google.com/task/13593477251917180301) started by @LokiMetaSmith*