### PR TITLE
Fix Mascot Wiggling Issue

### DIFF
--- a/src/mascot.js
+++ b/src/mascot.js
@@ -102,6 +102,10 @@ if (mascotContainer && mascotImg && mascotText) {
     }
   });
 
+  document.addEventListener("mouseleave", () => {
+    mascotContainer.classList.remove("wiggle");
+  });
+
   // Drag and Drop Logic
   mascotContainer.setAttribute("draggable", true);
 


### PR DESCRIPTION
Added a `mouseleave` event listener to `document` in `src/mascot.js` that removes the `wiggle` class from the `mascotContainer`. This ensures the mascot stops jiggling when the user pans entirely off the browser window.

---
*PR created automatically by Jules for task [817583638268829331](https://jules.google.com/task/817583638268829331) started by @LokiMetaSmith*