### PR TITLE
Fix: Allow emails as usernames in server validation

### DIFF
--- a/server/tests/username_validation.test.js
+++ b/server/tests/username_validation.test.js
@@ -58,7 +58,7 @@ describe('Username Validation', () => {
   };
 
   it('should accept valid usernames', async () => {
-    const validUsernames = ['testuser', 'valid_user', 'user-name', 'User123', 'short'];
+    const validUsernames = ['testuser', 'valid_user', 'user-name', 'User123', 'short', 'test@testing.com', 'user.name@example.co.uk'];
     for (const username of validUsernames) {
       const res = await register(username);
       expect(res.statusCode).toBe(200);
@@ -68,31 +68,25 @@ describe('Username Validation', () => {
   it('should reject usernames that are too short', async () => {
     const res = await register('ab');
     expect(res.statusCode).toBe(400);
-    expect(res.body.errors[0].msg).toContain('Username must be between 3 and 30 characters');
+    expect(res.body.errors[0].msg).toContain('Username must be between 3 and 255 characters');
   });
 
   it('should reject usernames that are too long', async () => {
-    const res = await register('a'.repeat(31));
+    const res = await register('a'.repeat(256));
     expect(res.statusCode).toBe(400);
-    expect(res.body.errors[0].msg).toContain('Username must be between 3 and 30 characters');
+    expect(res.body.errors[0].msg).toContain('Username must be between 3 and 255 characters');
   });
 
   it('should reject usernames with invalid characters (space)', async () => {
     const res = await register('user name');
     expect(res.statusCode).toBe(400);
-    expect(res.body.errors[0].msg).toContain('Username can only contain letters, numbers, underscores, and hyphens');
-  });
-
-  it('should reject usernames with invalid characters (@)', async () => {
-    const res = await register('user@name');
-    expect(res.statusCode).toBe(400);
-    expect(res.body.errors[0].msg).toContain('Username can only contain letters, numbers, underscores, and hyphens');
+    expect(res.body.errors[0].msg).toContain('Username can only contain letters, numbers, underscores, hyphens, @, and periods');
   });
 
   it('should reject usernames with HTML tags', async () => {
     const res = await register('<h1>hack</h1>');
     expect(res.statusCode).toBe(400);
-    expect(res.body.errors[0].msg).toContain('Username can only contain letters, numbers, underscores, and hyphens');
+    expect(res.body.errors[0].msg).toContain('Username can only contain letters, numbers, underscores, hyphens, @, and periods');
   });
 
   it('should reject prototype pollution keys', async () => {

--- a/server/validators.js
+++ b/server/validators.js
@@ -26,8 +26,8 @@ export const validateUsername = [
     .notEmpty().withMessage('Username is required')
     .isString().withMessage('Username must be a string')
     .trim()
-    .isLength({ min: 3, max: 30 }).withMessage('Username must be between 3 and 30 characters')
-    .matches(/^[a-zA-Z0-9_-]+$/).withMessage('Username can only contain letters, numbers, underscores, and hyphens')
+    .isLength({ min: 3, max: 255 }).withMessage('Username must be between 3 and 255 characters')
+    .matches(/^[a-zA-Z0-9_\-@.]+$/).withMessage('Username can only contain letters, numbers, underscores, hyphens, @, and periods')
     .custom(value => {
       if (sanitizeUsername(value) === null) {
         throw new Error('Invalid username');
@@ -42,8 +42,8 @@ export const validateUsernameQuery = [
     .notEmpty().withMessage('Username is required')
     .isString().withMessage('Username must be a string')
     .trim()
-    .isLength({ min: 3, max: 30 }).withMessage('Username must be between 3 and 30 characters')
-    .matches(/^[a-zA-Z0-9_-]+$/).withMessage('Username can only contain letters, numbers, underscores, and hyphens')
+    .isLength({ min: 3, max: 255 }).withMessage('Username must be between 3 and 255 characters')
+    .matches(/^[a-zA-Z0-9_\-@.]+$/).withMessage('Username can only contain letters, numbers, underscores, hyphens, @, and periods')
     .custom(value => {
       if (sanitizeUsername(value) === null) {
         throw new Error('Invalid username');


### PR DESCRIPTION
Fixes an issue where users trying to log in or register with an email address as their username received a 400 Bad Request error. The `express-validator` middleware previously only allowed letters, numbers, underscores, and hyphens up to 30 characters. The regex and length limits have been updated to support standard email formats.

---
*PR created automatically by Jules for task [9226702304383389752](https://jules.google.com/task/9226702304383389752) started by @LokiMetaSmith*