### PR TITLE
Fix "Invalid server token signature" during WebAuthn login by exposing session token header

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -500,6 +500,7 @@ async function startServer(
       },
       credentials: true,
       optionsSuccessStatus: 200,
+      exposedHeaders: ['X-Server-Session-Token'],
     };
     
    // app.use(limiter);


### PR DESCRIPTION
The user reported an "Invalid server token signature" error when attempting to log in with a WebAuthn security key. This error occurs in `src/printshop.js` when the client tries to verify a new server session token (`liveToken`) using the remote JWKS. However, because the `X-Server-Session-Token` header was not exposed in the server's CORS configuration (`server/server.js`), the `liveToken` was unreadable (or incorrectly parsed) by the browser's `fetch` API during cross-origin requests, leading to the verification failure. 

This PR fixes the issue by adding `exposedHeaders: ['X-Server-Session-Token']` to the CORS options, explicitly allowing the client to read the header.

---
*PR created automatically by Jules for task [6546082332007746501](https://jules.google.com/task/6546082332007746501) started by @LokiMetaSmith*