### PR TITLE
Add tooltips to icon-only buttons

### DIFF
--- a/UX_TODO.md
+++ b/UX_TODO.md
@@ -6,4 +6,4 @@ This is a list of proposed UX improvements for the Print Shop interface, ordered
 - [x] **Loading Spinners for Buttons:** Add inline loading spinners (or disable states) to action buttons (e.g., "Login", "Register", "Nest Stickers") to provide immediate visual feedback during async operations, replacing or supplementing the full-screen loader.
 - [x] **Enhanced Empty States:** Replace generic "Loading orders..." or "Please log in" text in the orders list with a more visually distinct and helpful empty state design.
 - [x] **Confirmation Modals for Destructive Actions:** Add a confirmation step (e.g., a native `confirm()` or a custom modal) before performing irreversible actions like changing an order status to "Canceled".
-- [ ] **ARIA Attributes and Tooltips:** Ensure all icon-only buttons (like modal close buttons) have proper `aria-label` attributes and consider adding hover/focus tooltips for small utility buttons to clarify their purpose.
+- [x] **ARIA Attributes and Tooltips:** Ensure all icon-only buttons (like modal close buttons) have proper `aria-label` attributes and consider adding hover/focus tooltips for small utility buttons to clarify their purpose.

--- a/printshop.html
+++ b/printshop.html
@@ -574,6 +574,7 @@
             id="close-modal-btn"
             class="text-2xl font-bold text-gray-500 hover:text-gray-800"
             aria-label="Close modal"
+            title="Close modal"
           >
             &times;
           </button>
@@ -661,6 +662,7 @@
         id="close-error-toast"
         class="ml-4 text-white font-bold hover:text-red-100 focus:outline-none focus:underline"
         aria-label="Close error message"
+        title="Close"
       >
         &times;
       </button>
@@ -677,6 +679,7 @@
         id="close-success-toast"
         class="ml-4 text-white font-bold hover:text-green-100 focus:outline-none focus:underline"
         aria-label="Close success message"
+        title="Close"
       >
         &times;
       </button>

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -95,7 +95,7 @@ class ToastManager {
     toast.innerHTML = `
       ${icon}
       <div class="ml-3 text-sm font-normal message-content" style="font-family: var(--font-baumans)"></div>
-      <button type="button" class="ml-auto -mx-1.5 -my-1.5 bg-white text-gray-400 hover:text-gray-900 rounded-lg focus:ring-2 focus:ring-gray-300 p-1.5 hover:bg-gray-100 inline-flex items-center justify-center h-8 w-8" aria-label="Close">
+      <button type="button" class="ml-auto -mx-1.5 -my-1.5 bg-white text-gray-400 hover:text-gray-900 rounded-lg focus:ring-2 focus:ring-gray-300 p-1.5 hover:bg-gray-100 inline-flex items-center justify-center h-8 w-8" aria-label="Close" title="Close">
         <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
             <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6"/>
         </svg>

--- a/src/orders.js
+++ b/src/orders.js
@@ -54,7 +54,7 @@ export function displayOrders(orders, container, noOrdersMessage) {
                     <div>
                         <h3 class="text-lg font-semibold text-splotch-red flex items-center gap-2">
                             Order ID: <span class="font-mono text-sm" title="${order.orderId}">${order.orderId.substring(0, 8)}...</span>
-                            <button class="copy-order-id-btn text-gray-500 hover:text-splotch-teal focus:outline-none transition-colors p-1 rounded-full hover:bg-gray-200" data-order-id="${order.orderId}" aria-label="Copy full Order ID">
+                            <button class="copy-order-id-btn text-gray-500 hover:text-splotch-teal focus:outline-none transition-colors p-1 rounded-full hover:bg-gray-200" data-order-id="${order.orderId}" aria-label="Copy full Order ID" title="Copy full Order ID">
                                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
                                   <path stroke-linecap="round" stroke-linejoin="round" d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184" />
                                 </svg>


### PR DESCRIPTION
- Added `title="Close modal"` to `#close-modal-btn` in `printshop.html`
- Added `title="Close"` to `#close-error-toast` and `#close-success-toast` in `printshop.html`
- Added `title="Close"` to the toast close button in `src/notifications.js`
- Added `title="Copy full Order ID"` to `.copy-order-id-btn` in `src/orders.js`
- Marked the "ARIA Attributes and Tooltips" task as complete in `UX_TODO.md`

---
*PR created automatically by Jules for task [3303682433648683713](https://jules.google.com/task/3303682433648683713) started by @LokiMetaSmith*