### PR TITLE
🎨 Palette: Improve disabled state and accessibility of image editing sliders

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2024-05-16 - Careful with Server Test Artifacts
 **Learning:** Be careful when running tests that might generate files in `server/uploads`. The `.gitignore` does not catch all test artifacts (like UUID named files), so they must be manually cleaned up or excluded from commits.
 **Action:** Check `git status` carefully before committing to ensure no unintended test output files are included.
+## 2026-03-04 - Explicitly Managing Disabled States for Editing Controls
+**Learning:** To ensure that all image editing controls (like sliders and buttons) correctly disable when no image is loaded, their specific DOM elements must be explicitly added to the `elements` array inside the `updateEditingButtonsState` function in `src/index.js`.
+**Action:** When adding new image-manipulation UI controls to `index.html`, always check `updateEditingButtonsState` to make sure they are appended to its internal `elements` list to maintain proper application state.


### PR DESCRIPTION
🎨 Palette: Accessibility and Disabled States for Sliders

💡 What:
- Added `cutlineSensitivitySlider`, `lazyLassoSlider`, and `cutlineOffsetSlider` to the `updateEditingButtonsState` logic in `src/index.js`.
- Added `aria-label` attributes to these sliders in `index.html`.

🎯 Why:
- The sliders remained interactive (visually and functionally) even when the editor was completely empty without an image, which was confusing and poor UX. By managing their disabled state alongside other controls, they now correctly dim and become unclickable.
- These `input type="range"` elements were missing explicit `aria-label`s, negatively impacting screen reader usability.

♿ Accessibility:
- Added `aria-label="Cutline offset slider"`
- Added `aria-label="Edge sensitivity slider"`
- Added `aria-label="Lazy lasso smoothing slider"`

📸 Before/After:
Before: The Edge Sensitivity, Cutline Offset, and Lazy Lasso sliders remained bold and draggable when the page loaded with no image.
After: The sliders are correctly reduced in opacity and explicitly disabled until an image is uploaded.

---
*PR created automatically by Jules for task [4517413796414063064](https://jules.google.com/task/4517413796414063064) started by @LokiMetaSmith*