### PR TITLE
🛡️ Sentinel: [HIGH] Stricter Rate Limiting for Email Triggering Endpoints

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -472,6 +472,20 @@ async function startServer(
       }) : undefined,
     });
     
+    // SECURITY: Stricter rate limiter for endpoints that trigger emails or temporary tokens
+    const emailTriggerLimiter = rateLimit({
+      windowMs: 15 * 60 * 1000, // 15 minutes
+      max: (process.env.ENABLE_RATE_LIMIT_TEST) ? 3 :
+           (process.env.NODE_ENV === 'test') ? 1000 : 3, // Very strict in production to prevent email spam
+      message: 'Too many requests from this IP, please try again after 15 minutes',
+      standardHeaders: true,
+      legacyHeaders: false,
+      store: redisClient ? new RateLimitRedisStore({
+          sendCommand: (...args) => redisClient.sendCommand(args),
+          prefix: 'rl:email:',
+      }) : undefined,
+    });
+
     const allowedOrigins = [
       'https://lokimetasmith.github.io',
     ];
@@ -1654,7 +1668,7 @@ async function startServer(
         }
     });
 
-    app.post('/api/auth/magic-login', authLimiter, [
+    app.post('/api/auth/magic-login', emailTriggerLimiter, [
       body('email').isEmail().withMessage('email is not valid'),
     ], async (req, res) => {
         const errors = validationResult(req);
@@ -1746,7 +1760,7 @@ async function startServer(
       });
     });
     
-    app.post('/api/auth/issue-temp-token', authLimiter, [
+    app.post('/api/auth/issue-temp-token', emailTriggerLimiter, [
       body('email').isEmail().withMessage('A valid email is required'),
     ], (req, res) => {
       const errors = validationResult(req);

--- a/server/tests/rateLimit.test.js
+++ b/server/tests/rateLimit.test.js
@@ -76,7 +76,7 @@ describe('Rate Limiting', () => {
     }
   });
 
-  it('should rate limit /api/auth/issue-temp-token', async () => {
+  it('should strictly rate limit /api/auth/issue-temp-token', async () => {
       const agent = request.agent(app);
 
       const csrfRes = await agent.get('/api/csrf-token');
@@ -85,14 +85,38 @@ describe('Rate Limiting', () => {
       // Use a unique IP for this test
       const ip = '5.6.7.8';
 
-      for (let i = 0; i < 15; i++) {
+      for (let i = 0; i < 5; i++) {
           const res = await agent
             .post('/api/auth/issue-temp-token')
             .set('X-CSRF-Token', csrfToken)
             .set('X-Forwarded-For', ip)
             .send({ email: `test${i}@example.com` });
 
-          if (i < 10) {
+          if (i < 3) {
+              expect(res.status).not.toBe(429);
+          } else {
+              expect(res.status).toBe(429);
+          }
+      }
+  });
+
+  it('should strictly rate limit /api/auth/magic-login', async () => {
+      const agent = request.agent(app);
+
+      const csrfRes = await agent.get('/api/csrf-token');
+      const csrfToken = csrfRes.body.csrfToken;
+
+      // Use a unique IP for this test
+      const ip = '9.10.11.12';
+
+      for (let i = 0; i < 5; i++) {
+          const res = await agent
+            .post('/api/auth/magic-login')
+            .set('X-CSRF-Token', csrfToken)
+            .set('X-Forwarded-For', ip)
+            .send({ email: `magic${i}@example.com` });
+
+          if (i < 3) {
               expect(res.status).not.toBe(429);
           } else {
               expect(res.status).toBe(429);


### PR DESCRIPTION
I've completed the security enhancements regarding rate limiting.

### Security Enhancements Added
1.  **Added Strict Rate Limiter**: I implemented a new `emailTriggerLimiter` alongside the existing `authLimiter` and `apiLimiter`.
2.  **Configured Thresholds**: The new limiter applies a very strict limit of 3 requests per 15 minutes to any endpoint it guards, utilizing its own Redis/Memory store prefix (`rl:email:`).
3.  **Targeted Endpoints Guarded**: The `/api/auth/magic-login` and `/api/auth/issue-temp-token` endpoints now utilize `emailTriggerLimiter`. Because both of these actively trigger emails, enforcing stricter boundaries here prevents enumeration and protects email reputation from automated spamming.
4.  **Verified Tests**: I have updated the rate limit test file (`server/tests/rateLimit.test.js`) to accurately reflect and test these stricter thresholds (changing the loop iterations to check boundary conditions). The complete test suite of 116 tests passes fully.

---
*PR created automatically by Jules for task [5558373676792896684](https://jules.google.com/task/5558373676792896684) started by @LokiMetaSmith*