### PR TITLE
🎨 Palette: Add keyboard focus state to Login Modal close button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 ## 2026-03-04 - Explicitly Managing Disabled States for Editing Controls
 **Learning:** To ensure that all image editing controls (like sliders and buttons) correctly disable when no image is loaded, their specific DOM elements must be explicitly added to the `elements` array inside the `updateEditingButtonsState` function in `src/index.js`.
 **Action:** When adding new image-manipulation UI controls to `index.html`, always check `updateEditingButtonsState` to make sure they are appended to its internal `elements` list to maintain proper application state.
+
+## 2026-03-05 - Adding Focus States for Accessibility in Utility Buttons
+**Learning:** Keyboard-only users need visual feedback for interactive elements. Even simple utility buttons (like the `close-modal-btn` on modal dialogues) require explicit `focus-visible` styles to ensure usability. Without them, a user tabbing through the page won't know when the "Close" button is active.
+**Action:** Always ensure custom button elements have Tailwind `focus-visible` classes (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 rounded`) alongside their normal/hover styling so they remain fully accessible.

--- a/printshop.html
+++ b/printshop.html
@@ -572,7 +572,7 @@
           <h2 class="text-2xl sm:text-3xl text-splotch-navy">Login</h2>
           <button
             id="close-modal-btn"
-            class="text-2xl font-bold text-gray-500 hover:text-gray-800"
+            class="text-2xl font-bold text-gray-500 hover:text-gray-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 rounded"
             aria-label="Close modal"
             title="Close modal"
           >


### PR DESCRIPTION
💡 **What**: Added visible keyboard focus states to the "Close" button inside the `printshop.html` login modal.
🎯 **Why**: Previously, the "Close" button relied solely on hover states and had no visual feedback for users navigating with a keyboard (using the `Tab` key). This made it very difficult to perceive when the button was focused.
♿ **Accessibility**: Keyboard users now receive a clear blue ring indicator when focusing the close button, greatly improving their ability to navigate the login modal and dismiss it.

---
*PR created automatically by Jules for task [3479760592516796296](https://jules.google.com/task/3479760592516796296) started by @LokiMetaSmith*