### PR TITLE
feat: hide smart cutline generation features behind easter egg

### DIFF
--- a/index.html
+++ b/index.html
@@ -452,7 +452,7 @@
                 >
               </div>
             </div>
-            <div class="flex flex-col justify-center items-center col-span-2">
+            <div id="cutlineSensitivityContainer" style="display: none;" class="flex flex-col justify-center items-center col-span-2">
               <label
                 for="cutlineSensitivitySlider"
                 class="text-xs text-gray-500 mb-1"
@@ -476,7 +476,7 @@
                 >
               </div>
             </div>
-            <div class="flex flex-col justify-center items-center col-span-2">
+            <div id="lazyLassoContainer" style="display: none;" class="flex flex-col justify-center items-center col-span-2">
               <label
                 for="lazyLassoSlider"
                 class="text-xs text-gray-500 mb-1"
@@ -503,6 +503,7 @@
             <button
               type="button"
               id="generateCutlineBtn"
+              style="display: none;"
               class="bg-teal-500 text-white col-span-2 sm:col-span-3 md:col-span-4 lg:col-span-4 xl:col-span-2 flex justify-center items-center gap-2 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-teal-500"
               data-tooltip="Generate Cutline from Image Alpha"
             >

--- a/src/index.js
+++ b/src/index.js
@@ -721,6 +721,9 @@ async function BootStrap() {
       const grayBtn = document.getElementById("grayscaleBtn");
       const sepBtn = document.getElementById("sepiaBtn");
       const textContainer = document.getElementById("text-editing-controls");
+      const cutlineSensitivityContainer = document.getElementById("cutlineSensitivityContainer");
+      const lazyLassoContainer = document.getElementById("lazyLassoContainer");
+      const generateCutlineBtn = document.getElementById("generateCutlineBtn");
 
       if (grayBtn) {
           grayBtn.style.display = "block";
@@ -729,6 +732,16 @@ async function BootStrap() {
       if (sepBtn) {
           sepBtn.style.display = "block";
           sepBtn.classList.remove("lg:hidden", "xl:block");
+      }
+
+      if (cutlineSensitivityContainer) {
+          cutlineSensitivityContainer.style.display = "flex";
+      }
+      if (lazyLassoContainer) {
+          lazyLassoContainer.style.display = "flex";
+      }
+      if (generateCutlineBtn) {
+          generateCutlineBtn.style.display = "flex";
       }
 
       const isDisabled = (!originalImage && basePolygons.length === 0);
@@ -1423,10 +1436,16 @@ function updateEditingButtonsState(disabled) {
   // Update styles for filter buttons based on easterEggUnlocked
   const grayBtn = document.getElementById("grayscaleBtn");
   const sepBtn = document.getElementById("sepiaBtn");
+  const cutlineSensitivityContainer = document.getElementById("cutlineSensitivityContainer");
+  const lazyLassoContainer = document.getElementById("lazyLassoContainer");
+  const generateCutlineBtn = document.getElementById("generateCutlineBtn");
 
   if (!easterEggUnlocked) {
       if (grayBtn) grayBtn.style.display = "none";
       if (sepBtn) sepBtn.style.display = "none";
+      if (cutlineSensitivityContainer) cutlineSensitivityContainer.style.display = "none";
+      if (lazyLassoContainer) lazyLassoContainer.style.display = "none";
+      if (generateCutlineBtn) generateCutlineBtn.style.display = "none";
   } else {
       if (grayBtn) {
           grayBtn.style.display = "block";
@@ -1435,6 +1454,15 @@ function updateEditingButtonsState(disabled) {
       if (sepBtn) {
           sepBtn.style.display = "block";
           sepBtn.classList.remove("lg:hidden", "xl:block");
+      }
+      if (cutlineSensitivityContainer) {
+          cutlineSensitivityContainer.style.display = "flex";
+      }
+      if (lazyLassoContainer) {
+          lazyLassoContainer.style.display = "flex";
+      }
+      if (generateCutlineBtn) {
+          generateCutlineBtn.style.display = "flex";
       }
   }
   if (canvasPlaceholder)


### PR DESCRIPTION
The user requested that the "auto generate cut lines" feature be hidden by default and only become accessible once the application's easter egg has been triggered.

This change wraps the "Edge Sensitivity" and "Lazy Lasso" sliders inside `div` elements with explicit IDs, and initially hides them along with the "Generate Smart Cutline" button via inline CSS (`display: none`). The Javascript logic within `updateEditingButtonsState` and the `easterEggUnlocked` event listener has been updated to dynamically toggle the display property of these elements when the easter egg flag is toggled on. 

This cleanly hides advanced cutline-generating features from the standard UI path.

---
*PR created automatically by Jules for task [16845941892448216446](https://jules.google.com/task/16845941892448216446) started by @LokiMetaSmith*