### PR TITLE
🎨 Palette: Add explicit focus-visible states to utility buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,7 @@
 ## 2026-03-05 - Adding Focus States for Accessibility in Utility Buttons
 **Learning:** Keyboard-only users need visual feedback for interactive elements. Even simple utility buttons (like the `close-modal-btn` on modal dialogues) require explicit `focus-visible` styles to ensure usability. Without them, a user tabbing through the page won't know when the "Close" button is active.
 **Action:** Always ensure custom button elements have Tailwind `focus-visible` classes (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 rounded`) alongside their normal/hover styling so they remain fully accessible.
+
+## 2026-03-06 - Dynamically Created Focus States
+**Learning:** Components created dynamically using `document.createElement`, such as toast notifications, often lack visual focus states necessary for keyboard navigation accessibility because they don't use standard styled component templates.
+**Action:** Always append Tailwind CSS's `focus-visible` utility classes (e.g., `focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2`) when dynamically generating interactive DOM elements to guarantee clear focus indicators for keyboard users.

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -95,7 +95,7 @@ class ToastManager {
     toast.innerHTML = `
       ${icon}
       <div class="ml-3 text-sm font-normal message-content" style="font-family: var(--font-baumans)"></div>
-      <button type="button" class="ml-auto -mx-1.5 -my-1.5 bg-white text-gray-400 hover:text-gray-900 rounded-lg focus:ring-2 focus:ring-gray-300 p-1.5 hover:bg-gray-100 inline-flex items-center justify-center h-8 w-8" aria-label="Close" title="Close">
+      <button type="button" class="ml-auto -mx-1.5 -my-1.5 bg-white text-gray-400 hover:text-gray-900 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-500 p-1.5 hover:bg-gray-100 inline-flex items-center justify-center h-8 w-8" aria-label="Close" title="Close">
         <svg class="w-3 h-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
             <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6"/>
         </svg>

--- a/src/orders.js
+++ b/src/orders.js
@@ -69,7 +69,7 @@ export function displayOrders(orders, container, noOrdersMessage) {
                     <div>
                         <h3 class="text-lg font-semibold text-splotch-red flex items-center gap-2">
                             Order ID: <span class="font-mono text-sm" title="${safeOrderId}">${safeOrderIdShort}...</span>
-                            <button class="copy-order-id-btn text-gray-500 hover:text-splotch-teal focus:outline-none transition-colors p-1 rounded-full hover:bg-gray-200" data-order-id="${safeOrderId}" aria-label="Copy full Order ID" title="Copy full Order ID">
+                            <button class="copy-order-id-btn text-gray-500 hover:text-splotch-teal focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-splotch-teal transition-colors p-1 rounded-full hover:bg-gray-200" data-order-id="${safeOrderId}" aria-label="Copy full Order ID" title="Copy full Order ID">
                                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
                                   <path stroke-linecap="round" stroke-linejoin="round" d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184" />
                                 </svg>


### PR DESCRIPTION
This PR introduces a small UX/accessibility improvement.

- **`src/notifications.js`**: Added `focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-500` to the dynamically created toast close button.
- **`src/orders.js`**: Added `focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-splotch-teal` to the dynamically created "Copy Order ID" button.
- **`.Jules/palette.md`**: Appended a critical learning related to styling dynamically generated interactive elements for proper keyboard accessibility.

---
*PR created automatically by Jules for task [9897308822900892618](https://jules.google.com/task/9897308822900892618) started by @LokiMetaSmith*