### PR TITLE
🛡️ Sentinel: [HIGH] Fix Stored XSS in admin Odoo config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -15,3 +15,8 @@
 **Vulnerability:** Truncating HTML escaped text with `substring(0, 8)` can cut off an HTML entity mid-way (e.g. `&quot;` becomes `&qu`) which leads to malformed rendering in the DOM.
 **Learning:** Always apply length limitations or substrings to the raw string *before* passing it into the `escapeHtml()` function.
 **Prevention:** Order of operations matters: `escapeHtml(rawString.substring(0, N))` rather than `escapeHtml(rawString).substring(0, N)`.
+
+## 2025-03-07 - XSS via Unescaped Attributes in innerHTML
+**Vulnerability:** A dynamic value (`odooId` from server config mappings) was interpolated directly into an HTML input attribute string via `.innerHTML`: `<input ... value="${odooId}">`. An attacker who modifies `currentMappings` via the admin API could inject quotes and script tags (e.g. `1"> <script>alert(1)</script>`) to perform a Stored XSS attack against admins.
+**Learning:** Even if data isn't meant to be rendered as text, placing it directly into HTML attribute strings without encoding allows attribute breakout attacks.
+**Prevention:** Always use `escapeHtml()` when interpolating any dynamic or server-provided data into `.innerHTML` template literals, including attribute values.

--- a/src/printshop.js
+++ b/src/printshop.js
@@ -1007,7 +1007,7 @@ async function renderMaterialMapping(currentMappings) {
             tr.innerHTML = `
                 <td class="py-2 px-4 border">${escapeHtml(mat.name)} (${escapeHtml(mat.id)})</td>
                 <td class="py-2 px-4 border">
-                    <input type="number" class="w-full p-1 border rounded mapping-input" data-key="${mat.id}" value="${odooId}">
+                    <input type="number" class="w-full p-1 border rounded mapping-input" data-key="${mat.id}" value="${escapeHtml(odooId)}">
                 </td>
             `;
             tbody.appendChild(tr);


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unsanitized dynamic values (`odooId` from server configuration mappings) were being directly interpolated into an HTML input's `value` attribute within an `.innerHTML` assignment in `src/printshop.js`'s `renderMaterialMapping` function. 
🎯 **Impact:** An attacker who could modify `currentMappings` via the admin API or server-side DB could inject quotes and script tags (e.g. `1"> <script>alert(1)</script>`) to perform a Stored XSS attack against admins when the page loads the mapping config.
🔧 **Fix:** Sanitized `odooId` via `escapeHtml(odooId)` within the template string assignment.
✅ **Verification:** Ran test suites, linting, production build and verified via a mock playwright script that the Odoo Material Mapping table still successfully renders without structural regressions. Recorded the learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [11254264588196248360](https://jules.google.com/task/11254264588196248360) started by @LokiMetaSmith*