### PR TITLE
🎨 Palette: Accessible Login Modal

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -21,3 +21,7 @@
 ## 2024-05-16 - Explicit Aria-Hidden on SVGs inside interactive elements
 **Learning:** Decorative SVGs inside buttons and interactive components might be announced redundantly by screen readers if they lack the `aria-hidden="true"` attribute.
 **Action:** When adding interactive elements like buttons that contain an SVG icon alongside text or an `aria-label`, always ensure the `<svg>` tag has `aria-hidden="true"`.
+
+## 2026-03-10 - Explicit Modal ARIA Attributes
+**Learning:** Custom HTML modal implementations (like `#login-modal` containers) require explicit `role="dialog"`, `aria-modal="true"`, and an `aria-labelledby` attribute pointing to the modal's title ID to ensure proper screen reader accessibility. Without these, screen readers may not announce the content appropriately as an active dialog box.
+**Action:** Always include `role="dialog"`, `aria-modal="true"`, and `aria-labelledby="[TitleID]"` on dynamically toggled or custom-built modal containers.

--- a/printshop.html
+++ b/printshop.html
@@ -564,12 +564,20 @@
     <div
       id="login-modal"
       class="hidden fixed inset-0 bg-gray-900 bg-opacity-75 flex items-center justify-center z-50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="loginModalTitle"
     >
       <div
         class="bg-white p-8 rounded-lg shadow-xl w-full max-w-md mx-4 sm:mx-0"
       >
         <div class="flex justify-between items-center mb-6">
-          <h2 class="text-2xl sm:text-3xl text-splotch-navy">Login</h2>
+          <h2
+            id="loginModalTitle"
+            class="text-2xl sm:text-3xl text-splotch-navy"
+          >
+            Login
+          </h2>
           <button
             id="close-modal-btn"
             class="text-2xl font-bold text-gray-500 hover:text-gray-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 rounded"


### PR DESCRIPTION
🎨 Palette: Accessible Login Modal

💡 **What:** Added `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` to the `#login-modal` in `printshop.html` and defined an `id` on its title to ensure screen reader compatibility.
🎯 **Why:** To clearly inform users relying on screen readers when a modal has intercepted the application flow and what the purpose of that dialog box is. Without these ARIA attributes, standard `div`-based custom modals fail to announce their presence properly.
♿ **Accessibility:** This directly resolves an issue where keyboard and screen reader users might not detect or understand that a modal has taken focus.

---
*PR created automatically by Jules for task [12703196357634149642](https://jules.google.com/task/12703196357634149642) started by @LokiMetaSmith*