### PR TITLE
Display uploaded filename natively in file input

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,10 +166,7 @@
                   aria-describedby="file-helper"
                 />
               </div>
-              <span
-                id="fileNameDisplay"
-                class="text-sm text-gray-600 ml-2"
-              ></span>
+
               <button
                 type="button"
                 id="clearFileBtn"

--- a/src/index.js
+++ b/src/index.js
@@ -69,8 +69,7 @@ let stickerMaterialSelect,
 let paymentStatusContainer,
   ipfsLinkContainer,
   fileInputGlobalRef,
-  paymentFormGlobalRef,
-  fileNameDisplayEl;
+  paymentFormGlobalRef;
 let rotateLeftBtnEl,
   rotateRightBtnEl,
   resetBtnEl,
@@ -200,7 +199,6 @@ async function BootStrap() {
   paymentStatusContainer = document.getElementById("payment-status-container");
   ipfsLinkContainer = document.getElementById("ipfsLinkContainer"); // This might be deprecated if IPFS is handled server-side
   fileInputGlobalRef = document.getElementById("file");
-  fileNameDisplayEl = document.getElementById("fileNameDisplay");
   paymentFormGlobalRef = document.getElementById("payment-form");
   submitPaymentBtn = document.getElementById("submitPaymentBtn");
   canvasPlaceholder = document.getElementById("canvas-placeholder");
@@ -1581,9 +1579,13 @@ function handleFileChange(event) {
 }
 
 function loadFileAsImage(file, isMascot = false) {
+  if (file && fileInputGlobalRef) {
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add(file);
+    fileInputGlobalRef.files = dataTransfer.files;
+  }
   if (!file) return;
 
-  if (fileNameDisplayEl) fileNameDisplayEl.textContent = file.name;
   const reader = new FileReader();
 
   // Handle SVGs differently from other images
@@ -2259,8 +2261,6 @@ function handleClearImage() {
   cleanCanvasState = null;
 
   if (fileInputGlobalRef) fileInputGlobalRef.value = "";
-  if (fileNameDisplayEl) fileNameDisplayEl.textContent = "";
-
   if (canvas && ctx) {
     // Reset to default size (matches HTML)
     setCanvasSize(500, 400);


### PR DESCRIPTION
Refactored the file upload section to utilize the browser's native `<input type="file">` text display instead of relying on a custom, external span.

The problem was that drag-and-dropped files or specially generated "mascot files" bypassed the native visual update of the file input. To address this, the `loadFileAsImage` function was updated to construct a `DataTransfer` object and assign its `.files` property directly to the input, ensuring that the filename natively shows up next to the "Choose File" button across all upload mechanisms consistently.

Unnecessary DOM variables (`fileNameDisplayEl`) and references were also removed.

---
*PR created automatically by Jules for task [13433979776836775262](https://jules.google.com/task/13433979776836775262) started by @LokiMetaSmith*