### PR TITLE
Fix Print Shop dashboard order rendering for non-admin users

### DIFF
--- a/server/cli.js
+++ b/server/cli.js
@@ -46,7 +46,8 @@ program
     .description('Add a new user')
     .argument('<username>', 'username')
     .argument('<password>', 'password')
-    .action(async (username, password) => {
+    .option('--admin', 'Grant admin privileges to the user')
+    .action(async (username, password, options) => {
         const existing = await db.getUser(username);
         if (existing) {
             console.log('User already exists');
@@ -60,11 +61,12 @@ program
             username,
             password: hashedPassword,
             credentials: [],
+            ...(options.admin ? { role: 'admin' } : {})
         };
 
         await db.createUser(user);
 
-        console.log(`User ${username} added successfully`);
+        console.log(`User ${username} added successfully${options.admin ? ' with admin privileges' : ''}`);
     });
 
 program

--- a/src/printshop.js
+++ b/src/printshop.js
@@ -538,9 +538,17 @@ async function fetchAndDisplayOrders(query = '') {
     } catch (error) {
         console.error('[SHOP] Error fetching orders:', error);
         updateConnectionStatus('error');
-        // Error is already shown by fetchWithAuth on 401, this handles other network errors
-        if (error.message !== 'Authentication failed') {
-           showErrorToast(`Could not fetch orders: ${error.message}`);
+        // Clear orders but keep message on error
+        ui.ordersList.innerHTML = '';
+        ui.ordersList.appendChild(ui.noOrdersMessage);
+
+        const noOrdersTextErr = document.getElementById('no-orders-text');
+
+        if (error.message.includes('Forbidden') || error.message.includes('permission')) {
+            if (noOrdersTextErr) noOrdersTextErr.textContent = 'Access Denied: You must be an administrator to view orders.';
+        } else if (error.message !== 'Authentication failed') {
+            if (noOrdersTextErr) noOrdersTextErr.textContent = `Error: Could not load orders (${error.message})`;
+            showErrorToast(`Could not fetch orders: ${error.message}`);
         }
     } finally {
         hideLoadingIndicator();
@@ -565,6 +573,11 @@ async function fetchAndDisplayMetrics() {
         }
     } catch (e) {
         console.error('Error fetching metrics', e);
+        if (e.message.includes('Forbidden') || e.message.includes('permission')) {
+            document.getElementById('metric-total-orders').textContent = 'N/A';
+            document.getElementById('metric-total-revenue').textContent = 'N/A';
+            document.getElementById('metric-recent-orders').textContent = 'N/A';
+        }
         document.getElementById('metric-server-status').textContent = 'Offline';
         document.getElementById('metric-server-status').classList.add('text-red-500');
         document.getElementById('metric-server-status').classList.remove('text-green-500');


### PR DESCRIPTION
The printshop dashboard requires the logged-in user to have admin privileges, but there was no way to create an admin via the CLI, and the frontend poorly handled the resulting 403 error.

This patch adds an `--admin` flag to `server/cli.js add-user` to explicitly grant admin roles upon user creation. It also refactors the UI rendering logic in `src/printshop.js` so that if a 403 occurs during either the `/api/orders` or `/api/admin/sales-metrics` fetches, the UI correctly clears the list and displays "Access Denied" or "N/A" metrics, preventing the dashboard from indefinitely hanging on "Loading orders...".

---
*PR created automatically by Jules for task [12353502121277762575](https://jules.google.com/task/12353502121277762575) started by @LokiMetaSmith*