### PR TITLE
Fix 500 error on design upload caused by CSRF token in FormData

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1164,7 +1164,6 @@ async function handlePaymentFormSubmit(event) {
     showPaymentStatus("Uploading design...", "info");
     const uploadFormData = new FormData();
     uploadFormData.append("designImage", designImageBlob, "design.png");
-    uploadFormData.append("_csrf", csrfToken); // Add CSRF token to form data
 
     const cutLineFileInput = document.getElementById("cutLineFile");
     if (cutLineFileInput && cutLineFileInput.files[0]) {
@@ -2988,7 +2987,6 @@ async function handleCreateProduct() {
     );
     const uploadFormData = new FormData();
     uploadFormData.append("designImage", designImageBlob, "design.png");
-    uploadFormData.append("_csrf", csrfToken);
 
     // Use existing upload endpoint
     const uploadResponse = await fetch(`${serverUrl}/api/upload-design`, {


### PR DESCRIPTION
Fixes a 500 Internal Server Error when uploading a sticker design during checkout. The error was caused by appending the `_csrf` token to the `FormData` body, which caused `multer`/`busboy` to crash on the backend. The token is already correctly transmitted via the `X-CSRF-Token` header, so removing it from the body safely resolves the issue.

---
*PR created automatically by Jules for task [6974749313818951144](https://jules.google.com/task/6974749313818951144) started by @LokiMetaSmith*