### PR TITLE
Fix editing controls layout and enable negative cutlines

### DIFF
--- a/index.html
+++ b/index.html
@@ -281,7 +281,7 @@
           <!-- Basic Image Editing Controls -->
           <div
             id="editing-controls"
-            class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-12 xl:grid-cols-12 gap-3 my-6 p-4 border border-gray-200 rounded-md shadow-sm bg-slate-50"
+            class="flex flex-wrap justify-center items-center gap-4 my-6 p-4 border border-gray-200 rounded-md shadow-sm bg-slate-50"
           >
             <button
               type="button"
@@ -365,7 +365,7 @@
                 />
               </svg>
             </button>
-            <div class="flex flex-col col-span-2">
+            <div class="flex flex-col">
               <label for="resizeInput" class="text-sm text-center block mb-1"
                 >Size:</label
               >
@@ -392,7 +392,7 @@
                 aria-label="Size slider"
               />
             </div>
-            <div class="flex flex-col justify-center items-center col-span-2">
+            <div class="flex flex-col justify-center items-center">
               <span class="text-xs text-gray-500 mb-1">Dimensions</span>
               <div class="flex items-center space-x-1">
                 <span
@@ -415,7 +415,7 @@
               id="grayscaleBtn"
               data-tooltip="Apply Grayscale Filter"
               aria-pressed="false"
-              class="lg:hidden xl:block focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-splotch-navy rounded"
+              class="focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-splotch-navy rounded"
               style="display: none"
             >
               Grayscale
@@ -425,12 +425,12 @@
               id="sepiaBtn"
               data-tooltip="Apply Sepia Filter"
               aria-pressed="false"
-              class="lg:hidden xl:block focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-splotch-red rounded"
+              class="focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-splotch-red rounded"
               style="display: none"
             >
               Sepia
             </button>
-            <div class="flex flex-col justify-center items-center col-span-2">
+            <div class="flex flex-col justify-center items-center w-full sm:w-auto min-w-[150px]">
               <label
                 for="cutlineOffsetSlider"
                 class="text-xs text-gray-500 mb-1"
@@ -440,7 +440,7 @@
                 <input
                   type="range"
                   id="cutlineOffsetSlider"
-                  min="0"
+                  min="-50"
                   max="50"
                   value="10"
                   step="1"
@@ -456,7 +456,7 @@
             <div
               id="cutlineSensitivityContainer"
               style="display: none"
-              class="flex flex-col justify-center items-center col-span-2"
+              class="flex flex-col justify-center items-center w-full sm:w-auto min-w-[150px]"
             >
               <label
                 for="cutlineSensitivitySlider"
@@ -484,7 +484,7 @@
             <div
               id="lazyLassoContainer"
               style="display: none"
-              class="flex flex-col justify-center items-center col-span-2"
+              class="flex flex-col justify-center items-center w-full sm:w-auto min-w-[150px]"
             >
               <label for="lazyLassoSlider" class="text-xs text-gray-500 mb-1"
                 >Lazy Lasso</label
@@ -511,7 +511,7 @@
               type="button"
               id="generateCutlineBtn"
               style="display: none"
-              class="bg-teal-500 text-white col-span-2 sm:col-span-3 md:col-span-4 lg:col-span-4 xl:col-span-2 flex justify-center items-center gap-2 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-teal-500"
+              class="bg-teal-500 text-white flex justify-center items-center gap-2 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-teal-500 w-full sm:w-auto"
               data-tooltip="Generate Cutline from Image Alpha"
             >
               Generate Smart Cutline

--- a/src/index.js
+++ b/src/index.js
@@ -743,11 +743,9 @@ async function BootStrap() {
 
       if (grayBtn) {
         grayBtn.style.display = "block";
-        grayBtn.classList.remove("lg:hidden", "xl:block");
       }
       if (sepBtn) {
         sepBtn.style.display = "block";
-        sepBtn.classList.remove("lg:hidden", "xl:block");
       }
 
       if (cutlineSensitivityContainer) {
@@ -1475,11 +1473,9 @@ function updateEditingButtonsState(disabled) {
   } else {
     if (grayBtn) {
       grayBtn.style.display = disabled ? "none" : "block";
-      if (!disabled) grayBtn.classList.remove("lg:hidden", "xl:block");
     }
     if (sepBtn) {
       sepBtn.style.display = disabled ? "none" : "block";
-      if (!disabled) sepBtn.classList.remove("lg:hidden", "xl:block");
     }
     if (cutlineSensitivityContainer) {
       cutlineSensitivityContainer.style.display = disabled ? "none" : "flex";


### PR DESCRIPTION
This PR addresses two UX issues in the sticker editor:
1. **Control Panel Jumbling:** Converted the editing controls container (`#editing-controls`) from CSS Grid to Flexbox. The rigid grid was prone to overlap and layout breaking (jumbling) during zoom or when elements like the filter buttons toggled visibility. The flex-wrap approach ensures buttons stack safely regardless of viewport or scaling.
2. **Negative Cutlines:** Changed the `min` attribute on the cutline offset slider from `0` to `-50`. Since the backend image processing (`Clipper.js`) already correctly handles negative paths (erosion vs. dilation), this simple HTML change fulfills the feature request to allow users to "cut into" their uploaded stickers.

---
*PR created automatically by Jules for task [17587446367598885684](https://jules.google.com/task/17587446367598885684) started by @LokiMetaSmith*