### PR TITLE
chore: migrate from docker-compose to docker compose

### DIFF
--- a/docs/backups.md
+++ b/docs/backups.md
@@ -139,7 +139,7 @@ If you need to restore your application's state from a backup:
 
 2.  **Stop the Application:** Ensure your application server is stopped to prevent data corruption. If using the `docker-compose.yml` from the `cloud-config`, you can run:
     ```bash
-    cd /path/to/project && docker-compose down
+    cd /path/to/project && docker compose down
     ```
 
 3.  **Extract the Backup:** From the **root of your project directory**, extract the archive. This will overwrite the existing `server/db.json` and `server/uploads/` directory.
@@ -151,7 +151,7 @@ If you need to restore your application's state from a backup:
 
 4.  **Restart the Application:**
     ```bash
-    cd /path/to/project && docker-compose up -d
+    cd /path/to/project && docker compose up -d
     ```
 
 Your application is now restored to the state of the backup.

--- a/docs/cloud-config.example.yml
+++ b/docs/cloud-config.example.yml
@@ -19,7 +19,7 @@ users:
 # 3. Install Docker and Docker Compose
 packages:
   - docker.io
-  - docker-compose
+  - docker-compose-v2
 
 # 4. Define the files to be created on the server
 write_files:
@@ -124,4 +124,4 @@ runcmd:
   # Build the frontend assets
   - cd /home/loki/lokimetasmith.github.io && npm install && npm run build
   # Launch the application using Docker Compose
-  - cd /home/loki/lokimetasmith.github.io && docker-compose up -d
+  - cd /home/loki/lokimetasmith.github.io && docker compose up -d

--- a/docs/deployment/homelab-proxmox.md
+++ b/docs/deployment/homelab-proxmox.md
@@ -123,7 +123,7 @@ Once the LXC is running, open its console from the Proxmox UI.
 3.  **Install Docker Compose:**
 
     ```bash
-    apt install docker-compose -y
+    apt install docker-compose-v2 -y
     ```
 
     > **Note on Podman:** As a more secure, daemonless alternative to Docker, you can install `podman` and `podman-compose` instead. The commands used in this guide are interchangeable.
@@ -157,7 +157,7 @@ Once the LXC is running, open its console from the Proxmox UI.
 4.  **Save the file** (`CTRL+X`, then `Y`, then `Enter`).
 5.  **Start the container:**
     ```bash
-    docker-compose up -d
+    docker compose up -d
     ```
 
 ### Initial Configuration
@@ -214,7 +214,7 @@ Open the console for your new app container.
     sh get-docker.sh
 
     # Install other tools
-    apt install docker-compose git nodejs npm -y
+    apt install docker-compose-v2 git nodejs npm -y
     ```
 
     > **Note on Podman:** You can use `podman` and `podman-compose` here as well. The rest of the steps remain the same.
@@ -246,7 +246,7 @@ With all the files in place, start the application using Docker Compose.
 
 ```bash
 # From the project root (/opt/print-shop)
-docker-compose up -d
+docker compose up -d
 ```
 
 The application is now running. The frontend is accessible within your local network at `http://192.168.1.20:8080`.

--- a/docs/deployment/local-docker.md
+++ b/docs/deployment/local-docker.md
@@ -61,7 +61,7 @@ Once the setup is complete, you can start the application.
     Run the following command from the project root directory:
 
     ```bash
-    docker-compose up --build
+    docker compose up --build
     ```
 
     - The `--build` flag is recommended on the first run to ensure the images are built correctly.
@@ -78,5 +78,5 @@ To stop the containers, press `CTRL+C` in the terminal where `docker-compose` is
 To stop the containers and remove the networks and volumes created, run:
 
 ```bash
-docker-compose down
+docker compose down
 ```

--- a/docs/deployment/remote-vps.md
+++ b/docs/deployment/remote-vps.md
@@ -114,10 +114,10 @@ The server is now running, but you must perform a few manual steps to finalize t
     cd /home/loki/lokimetasmith.github.io
 
     # For Standard Deployment:
-    docker-compose -f docker-compose.prod.yml restart
+    docker compose -f docker-compose.prod.yml restart
 
     # For Lite Deployment:
-    docker-compose -f docker-compose.lite.yml restart
+    docker compose -f docker-compose.lite.yml restart
     ```
 
 4.  **Update DNS (Optional but Recommended)**:

--- a/docs/digitalocean-cloud-config.yml
+++ b/docs/digitalocean-cloud-config.yml
@@ -35,7 +35,7 @@ users:
 # Installs Docker and Docker Compose, which are required to run the containerized application.
 packages:
   - docker.io
-  - docker-compose
+  - docker-compose-v2
   - getssl
   - cron
 
@@ -115,7 +115,7 @@ runcmd:
   - cd /home/loki/lokimetasmith.github.io && npm install && npm run build
   # 5. Launch the application using Docker Compose in detached mode
   # Note: We use docker-compose.prod.yml which is now part of the repository
-  - cd /home/loki/lokimetasmith.github.io && docker-compose -f DOCKER_COMPOSE_FILENAME up -d
+  - cd /home/loki/lokimetasmith.github.io && docker compose -f DOCKER_COMPOSE_FILENAME up -d
   # 6. Create ACME challenge directory
   - mkdir -p /home/loki/lokimetasmith.github.io/dist/.well-known/acme-challenge
   - chown -R loki:loki /home/loki/lokimetasmith.github.io/dist/.well-known
@@ -140,7 +140,7 @@ runcmd:
   # 9. Get the initial certificate and reload nginx
   - |
     runuser -l loki -c 'getssl -f YOUR_DOMAIN_OR_IP'
-  - cd /home/loki/lokimetasmith.github.io && docker-compose -f DOCKER_COMPOSE_FILENAME exec nginx nginx -s reload
+  - cd /home/loki/lokimetasmith.github.io && docker compose -f DOCKER_COMPOSE_FILENAME exec nginx nginx -s reload
   # 10. Set up cron job for renewal
   - |
-    (crontab -l -u loki 2>/dev/null; echo "0 1 * * * /usr/bin/getssl -u -a -q && /usr/bin/docker-compose -f /home/loki/lokimetasmith.github.io/DOCKER_COMPOSE_FILENAME exec nginx nginx -s reload") | crontab -u loki -
+    (crontab -l -u loki 2>/dev/null; echo "0 1 * * * /usr/bin/getssl -u -a -q && /usr/bin/docker compose -f /home/loki/lokimetasmith.github.io/DOCKER_COMPOSE_FILENAME exec nginx nginx -s reload") | crontab -u loki -

--- a/docs/proxmox-cloud-config.yml
+++ b/docs/proxmox-cloud-config.yml
@@ -29,7 +29,7 @@ users:
 # Installs Docker and Docker Compose, which are required to run the containerized application.
 packages:
   - docker.io
-  - docker-compose
+  - docker-compose-v2
   - getssl
   - cron
 
@@ -98,7 +98,7 @@ runcmd:
   # 4. Build the frontend assets
   - cd /home/loki/lokimetasmith.github.io && npm install && npm run build
   # 5. Launch the application using Docker Compose in detached mode
-  - cd /home/loki/lokimetasmith.github.io && docker-compose -f docker-compose.prod.yml up -d
+  - cd /home/loki/lokimetasmith.github.io && docker compose -f docker-compose.prod.yml up -d
   # 6. Create ACME challenge directory
   - mkdir -p /home/loki/lokimetasmith.github.io/dist/.well-known/acme-challenge
   - chown -R loki:loki /home/loki/lokimetasmith.github.io/dist/.well-known
@@ -123,7 +123,7 @@ runcmd:
   # 9. Get the initial certificate and reload nginx
   - |
     runuser -l loki -c 'getssl -f YOUR_DOMAIN_OR_IP'
-  - cd /home/loki/lokimetasmith.github.io && docker-compose -f docker-compose.prod.yml exec nginx nginx -s reload
+  - cd /home/loki/lokimetasmith.github.io && docker compose -f docker-compose.prod.yml exec nginx nginx -s reload
   # 10. Set up cron job for renewal
   - |
-    (crontab -l -u loki 2>/dev/null; echo "0 1 * * * /usr/bin/getssl -u -a -q && /usr/bin/docker-compose -f /home/loki/lokimetasmith.github.io/docker-compose.prod.yml exec nginx nginx -s reload") | crontab -u loki -
+    (crontab -l -u loki 2>/dev/null; echo "0 1 * * * /usr/bin/getssl -u -a -q && /usr/bin/docker compose -f /home/loki/lokimetasmith.github.io/docker-compose.prod.yml exec nginx nginx -s reload") | crontab -u loki -

--- a/scripts/deploy-digitalocean.sh
+++ b/scripts/deploy-digitalocean.sh
@@ -261,9 +261,9 @@ echo
 echo "3. After SSHing in, you may need to restart the services for the changes to take effect:"
 echo
 if [ "$USE_LITE" = true ]; then
-  echo "   cd /home/loki/lokimetasmith.github.io && docker-compose -f docker-compose.lite.yml restart"
+  echo "   cd /home/loki/lokimetasmith.github.io && docker compose -f docker-compose.lite.yml restart"
 else
-  echo "   cd /home/loki/lokimetasmith.github.io && docker-compose -f docker-compose.prod.yml restart"
+  echo "   cd /home/loki/lokimetasmith.github.io && docker compose -f docker-compose.prod.yml restart"
 fi
 echo
 echo "Deployment script finished."


### PR DESCRIPTION
Updates the cloud-config templates, deployment documentation, and shell scripts to rely on the modern `docker-compose-v2` package instead of the legacy `docker-compose` binary. All CLI invocations of `docker-compose` have been substituted with `docker compose` to reflect standard Docker plugin execution.

---
*PR created automatically by Jules for task [10231354585449111302](https://jules.google.com/task/10231354585449111302) started by @LokiMetaSmith*