### PR TITLE
Add start script for backend and frontend

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+echo "Starting backend server..."
+(cd server && pnpm start) &
+BACKEND_PID=$!
+
+echo "Starting frontend dev server..."
+pnpm dev &
+FRONTEND_PID=$!
+
+# Trap SIGINT and SIGTERM to kill the child processes cleanly
+trap 'echo "Stopping servers..."; kill $BACKEND_PID $FRONTEND_PID 2>/dev/null; exit' SIGINT SIGTERM
+
+echo "Servers started. Press Ctrl+C to stop."
+
+# Wait for both processes
+wait $BACKEND_PID
+wait $FRONTEND_PID


### PR DESCRIPTION
Added a shell script `start.sh` to cleanly start up the backend server and frontend website together in the background, making local development simpler. The script gracefully handles termination by killing the child processes.

---
*PR created automatically by Jules for task [2298208598148893558](https://jules.google.com/task/2298208598148893558) started by @LokiMetaSmith*