### PR TITLE
feat(dev): enable HTTPS for local vite server

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@playwright/test": "^1.58.2",
     "@tailwindcss/cli": "^4.1.18",
     "@tailwindcss/postcss": "^4.1.14",
+    "@vitejs/plugin-basic-ssl": "^2.3.0",
     "autoprefixer": "^10.4.23",
     "eslint": "^9.35.0",
     "globals": "^17.0.0",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -3,7 +3,7 @@ import { defineConfig, devices } from '@playwright/test';
 export default defineConfig({
   webServer: {
     command: 'npm run dev',
-    url: 'http://localhost:5173', // Vite's default port
+    url: 'https://localhost:5173', // Vite's default port
     reuseExistingServer: !process.env.CI, // Reuse server in local dev for speed
     // Set a higher timeout for the server to start
     timeout: 120 * 1000,
@@ -11,12 +11,14 @@ export default defineConfig({
       SQUARE_ACCESS_TOKEN: 'dummy-token-for-testing',
       NODE_ENV: 'test',
     },
+    ignoreHTTPSErrors: true,
   },
   use: {
-    baseURL: 'http://localhost:5173', // Match the webServer port
+    baseURL: 'https://localhost:5173', // Match the webServer port
     headless: true,
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
+    ignoreHTTPSErrors: true,
   },
   projects: [
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.1.14
         version: 4.1.18
+      '@vitejs/plugin-basic-ssl':
+        specifier: ^2.3.0
+        version: 2.3.0(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
       autoprefixer:
         specifier: ^10.4.23
         version: 10.4.23(postcss@8.5.6)
@@ -1496,6 +1499,12 @@ packages:
     resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
     cpu: [x64]
     os: [win32]
+
+  '@vitejs/plugin-basic-ssl@2.3.0':
+    resolution: {integrity: sha512-bdyo8rB3NnQbikdMpHaML9Z1OZPBu6fFOBo+OtxsBlvMJtysWskmBcnbIDhUqgC8tcxNv/a+BcV5U+2nQMm1OQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    peerDependencies:
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
 
   '@zeit/schemas@2.36.0':
     resolution: {integrity: sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==}
@@ -5663,6 +5672,10 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
+
+  '@vitejs/plugin-basic-ssl@2.3.0(vite@7.3.1(@types/node@25.0.10)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))':
+    dependencies:
+      vite: 7.3.1(@types/node@25.0.10)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
 
   '@zeit/schemas@2.36.0': {}
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,8 +2,12 @@ import { defineConfig } from 'vite';
 import { resolve } from 'path';
 import tailwindcss from '@tailwindcss/postcss';
 import autoprefixer from 'autoprefixer';
+import basicSsl from '@vitejs/plugin-basic-ssl';
 
 export default defineConfig({
+  plugins: [
+    basicSsl()
+  ],
   build: {
     rollupOptions: {
       input: {


### PR DESCRIPTION
This commit adds the `@vitejs/plugin-basic-ssl` plugin to enable HTTPS on the Vite development server. This is required because the Square Payments SDK enforces secure context (HTTPS) constraints, even when running locally on an IP address. The Playwright configuration was also updated to ignore the self-signed certificate errors to ensure the end-to-end testing pipeline remains operational.

---
*PR created automatically by Jules for task [3095599569778891901](https://jules.google.com/task/3095599569778891901) started by @LokiMetaSmith*