### PR TITLE
chore: resolve vite basic ssl dependency error

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+echo "Installing root dependencies..."
+pnpm install
+
+echo "Installing server dependencies..."
+(cd server && pnpm install)
+
 echo "Starting backend server..."
 (cd server && pnpm start) &
 BACKEND_PID=$!


### PR DESCRIPTION
Resolved the `ERR_MODULE_NOT_FOUND` issue with `@vitejs/plugin-basic-ssl` by running a fresh `pnpm install`. The root cause was missing or out-of-sync dependencies in `node_modules` rather than a configuration error. Validated with full passing unit and e2e test suites.

---
*PR created automatically by Jules for task [7262842805594917317](https://jules.google.com/task/7262842805594917317) started by @LokiMetaSmith*