### PR TITLE
Fix pricing `$NaN` evaluation on initial load and CORS errors

### DIFF
--- a/playwright_tests/nesting.spec.cjs
+++ b/playwright_tests/nesting.spec.cjs
@@ -46,7 +46,7 @@ test.describe('Nesting Functionality', () => {
             localStorage.setItem('authToken', 'mock-jwt-token');
         });
 
-        await page.goto('http://localhost:5173/printshop.html');
+        await page.goto('/printshop.html');
 
         // Wait for orders to load
         await expect(page.locator('#order-card-order-nest-1')).toBeVisible();

--- a/playwright_tests/payment-form.spec.js
+++ b/playwright_tests/payment-form.spec.js
@@ -56,10 +56,10 @@ test.describe('Payment Form Flow', () => {
 
     // 5. Verify processing status
     // Wait for the status container to be visible (it might be visible from previous step, so we check content)
-    await expect(page.locator('.message-content').last()).toBeVisible();
+    await expect(page.locator('#payment-status-container')).toBeVisible();
 
     // 6. Verify success message
-    await expect(page.locator('.message-content').last()).toContainText('Order successfully placed!', { timeout: 10000 });
+    await expect(page.locator('#payment-status-container')).toContainText('Order successfully placed!', { timeout: 10000 });
 
     // 7. Verify redirection to orders page
     await page.waitForURL('**/orders.html?token=mock-temp-auth-token-xyz', { timeout: 10000 });

--- a/playwright_tests/verify_optimization.spec.cjs
+++ b/playwright_tests/verify_optimization.spec.cjs
@@ -56,7 +56,7 @@ test.describe('Bolt Optimization Verification', () => {
             localStorage.setItem('authToken', 'mock-jwt-token');
         });
 
-        await page.goto('http://localhost:5173/printshop.html');
+        await page.goto('/printshop.html');
 
         // Wait for orders to load
         await expect(page.locator('.order-card')).toHaveCount(2);

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ import { showNotification } from "./notifications.js";
 
 const appId = "sandbox-sq0idb-tawTw_Vl7VGYI6CZfKEshA";
 const locationId = "LTS82DEX24XR0";
-const serverUrl = "http://localhost:3000"; // Define server URL once
+const serverUrl = ""; // Define server URL once
 
 // Declare globals for SDK objects and key DOM elements
 let payments, card, csrfToken;
@@ -1507,7 +1507,7 @@ function setCanvasSize(logicalWidth, logicalHeight) {
   let ppi = 96;
   if (pricingConfig && stickerResolutionSelect) {
     const selectedRes = pricingConfig.resolutions.find(
-      (r) => r.id === stickerResolutionSelect.value,
+      (r) => r.id === (stickerResolutionSelect.value || "dpi_300"),
     );
     if (selectedRes) {
       ppi = selectedRes.ppi;
@@ -1825,7 +1825,7 @@ function generateCutLine(polygons, rawOffset, rawLazyRadius = 0) {
     stickerResolutionSelect
   ) {
     const selectedRes = pricingConfig.resolutions.find(
-      (r) => r.id === stickerResolutionSelect.value,
+      (r) => r.id === (stickerResolutionSelect.value || "dpi_300"),
     );
     if (selectedRes) {
       ppi = selectedRes.ppi;
@@ -2079,7 +2079,7 @@ function drawSizeIndicator(bounds, offset = { x: 0, y: 0 }) {
 
   const ppi =
     pricingConfig.resolutions.find(
-      (r) => r.id === stickerResolutionSelect.value,
+      (r) => r.id === (stickerResolutionSelect.value || "dpi_300"),
     )?.ppi || 96;
   let width = bounds.width / ppi;
   let height = bounds.height / ppi;
@@ -2233,7 +2233,7 @@ function drawRuler(bounds, offset = { x: 0, y: 0 }) {
   if (!ctx || !bounds || !pricingConfig || !stickerResolutionSelect) return;
   const ppi =
     pricingConfig.resolutions.find(
-      (r) => r.id === stickerResolutionSelect.value,
+      (r) => r.id === (stickerResolutionSelect.value || "dpi_300"),
     )?.ppi || 96;
   drawCanvasRuler(ctx, bounds, offset, ppi, isMetric);
 }
@@ -2362,7 +2362,7 @@ function handleResetImage() {
       if (resizeSliderEl) {
         if (pricingConfig && stickerResolutionSelect) {
           const selectedResolution = pricingConfig.resolutions.find(
-            (r) => r.id === stickerResolutionSelect.value,
+            (r) => r.id === (stickerResolutionSelect.value || "dpi_300"),
           );
           const ppi = selectedResolution ? selectedResolution.ppi : 96;
           let maxDimPixels = Math.max(newWidth, newHeight);
@@ -2845,7 +2845,7 @@ function handleGenerateCutline() {
       // Constraint: "we can have internal cuts, but they should be less than 2mm"
       // Interpretation: Keep internal cuts <= 2mm. Remove internal cuts > 2mm.
       if (significantContours.length > 0) {
-        const selectedResolutionId = stickerResolutionSelect
+        const selectedResolutionId = (stickerResolutionSelect && stickerResolutionSelect.value)
           ? stickerResolutionSelect.value
           : "dpi_300";
         const selectedResolution =

--- a/src/magic-login.js
+++ b/src/magic-login.js
@@ -1,4 +1,4 @@
-const serverUrl = "http://localhost:3000";
+const serverUrl = "";
 let csrfToken;
 
 const loginStatus = document.getElementById("login-status");


### PR DESCRIPTION
Resolves issues where the user's sticker design pricing calculation failed with `$NaN` and visual dimensions rendered as "--- x ---". This occurred because the dropdown selection for DPI defaulted to an empty string during initial image load, causing a configuration lookup miss. Additionally, corrected the API requests to leverage the dev server's proxy dynamically instead of calling `localhost:3000` via HTTP directly, which prevented `pricing-info` from loading on HTTPS environments.

---
*PR created automatically by Jules for task [17723176809204305062](https://jules.google.com/task/17723176809204305062) started by @LokiMetaSmith*