### PR TITLE
fix(cors): allow https for localhost domains

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -491,7 +491,7 @@ async function startServer(
     ];
     
     if (process.env.NODE_ENV !== 'production') {
-      allowedOrigins.push(/http:\/\/localhost:\d+/);
+      allowedOrigins.push(/https?:\/\/(localhost|127\.0\.0\.1):\d+/);
     }
     
     const corsOptions = {


### PR DESCRIPTION
Updated the CORS allowed origins regex in non-production environments to support both `http://` and `https://` for `localhost` and `127.0.0.1`. This fixes the "Not allowed by CORS" errors when the frontend is served via HTTPS using Vite's `basicSsl` plugin.

---
*PR created automatically by Jules for task [10594764456847971669](https://jules.google.com/task/10594764456847971669) started by @LokiMetaSmith*