### PR TITLE
feat: Add app version to site footers

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,7 +15,8 @@ export default [
         ...globals.jest,
         myCustomGlobal: "readonly",
         ClipperLib: "readonly",
-        SVGNest: "readonly"
+        SVGNest: "readonly",
+        __APP_VERSION__: "readonly"
       }
     },
     rules: {

--- a/index.html
+++ b/index.html
@@ -1187,7 +1187,7 @@
         <a href="/terms.html" class="text-splotch-red hover:underline"
           >Terms & FAQ</a
         >
-      </div>
+       | <span class="text-xs text-gray-400 ml-2">v<span class="app-version-display"></span></span></div>
     </footer>
 
     <div
@@ -1203,5 +1203,6 @@
       </div>
       <img id="mascot-img" src="/mascot.png" alt="Splotch Mascot" />
     </div>
-  </body>
+    <script type="module" src="./src/version.js"></script>
+</body>
 </html>

--- a/magic-login.html
+++ b/magic-login.html
@@ -40,7 +40,8 @@
     <footer class="bg-white shadow-md mt-8">
         <div class="container mx-auto px-6 py-3 text-center text-gray-500">
             &copy; 2025 Splotch | <a href="/terms.html" class="text-splotch-red hover:underline">Terms & FAQ</a>
-        </div>
+         | <span class="text-xs text-gray-400 ml-2">v<span class="app-version-display"></span></span></div>
     </footer>
+  <script type="module" src="./src/version.js"></script>
 </body>
 </html>

--- a/orders.html
+++ b/orders.html
@@ -198,7 +198,8 @@
         <a href="/terms.html" class="text-splotch-red hover:underline"
           >Terms & FAQ</a
         >
-      </div>
+       | <span class="text-xs text-gray-400 ml-2">v<span class="app-version-display"></span></span></div>
     </footer>
-  </body>
+    <script type="module" src="./src/version.js"></script>
+</body>
 </html>

--- a/plan.md
+++ b/plan.md
@@ -1,21 +1,15 @@
-1. **Understand the Goal**: The user wants to convert the plain text note "Keep important elements 2-3mm from edge!" into a "bubble text" style that does not occlude the artwork. Currently, it's a `<p>` tag positioned `absolute bottom-2 right-2` inside the `canvas-container`.
-2. **Current Implementation**:
-   - `index.html` has:
-     ```html
-     <p
-       id="designMarginNote"
-       class="absolute bottom-2 right-2 text-xs text-splotch-red p-1 bg-white bg-opacity-75 rounded"
-       style="font-family: var(--font-baumans); display: none"
-       contenteditable="false"
-     >
-       Keep important elements 2-3mm from edge!
-     </p>
-     ```
-3. **Proposed Changes**:
-   - To make it a "bubble text", we can change its styling in `index.html`. We can use a combination of padding, border-radius, background color, text color, and perhaps a small triangle (using `::after` or a small SVG) pointing towards the image, or simply styling it as a floating pill/bubble.
-   - To prevent it from occluding the artwork, we can move it *outside* the canvas (e.g., just below it), or position it in a way that it floats outside the bounding box of the canvas, but since the canvas container is `relative w-fit mx-auto`, placing it absolutely *outside* (e.g., `bottom: -30px`) might be better. Or we can just put it below the canvas container in the normal flow.
-   - Wait, if it's currently inside `#canvas-container`, it overlaps the canvas. If we move it outside the absolute positioning to be a block below the canvas, it won't occlude the artwork.
-   - Let's look at the image provided by the user: The text is right below the image bounding box, stylized as a red pill/bubble with a green circle drawn around it by the user. In the user's screenshot, it looks like it's currently a text floating *over* the bottom part of the canvas (occluding the dashed red cutline). The user says "make this a bubble text that doesn't occlude the artwork".
-   - So I should:
-     1. Move the `p#designMarginNote` outside of the `canvas` overlap.
-     2. Style it to look like a bubble.
+1. **Update `vite.config.js`**
+   - Import `fs` to read `package.json`.
+   - Add `__APP_VERSION__: JSON.stringify(packageJson.version)` to Vite's environment variables using the `define` option.
+2. **Update HTML footers**
+   - Add a span element to the footers of the relevant HTML files (`index.html`, `printshop.html`, `magic-login.html`, `orders.html`, `terms.html`) to display the version number. Give it an ID `app-version-display`.
+   - E.g.: `<span class="text-xs text-gray-400 ml-2">v<span id="app-version-display"></span></span>`
+3. **Update JavaScript to populate the version**
+   - Create a small new script `src/version.js` that sets the text content of `app-version-display` to `__APP_VERSION__`.
+   - Inject `<script type="module" src="./src/version.js" defer></script>` (or `/src/version.js` as appropriate) into the `<head>` or `<body>` of all HTML files that have a footer.
+4. **Test the changes**
+   - Run `pnpm build` to verify the build completes.
+   - Run `pnpm run test:unit` and `pnpm run test:e2e` to ensure no tests are broken.
+5. **Complete pre commit steps**
+   - Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+6. **Submit changes**

--- a/printshop.html
+++ b/printshop.html
@@ -664,7 +664,7 @@
     <footer class="bg-white shadow-md mt-8">
       <div class="container mx-auto px-6 py-3 text-center text-gray-500">
         &copy; 2026 Splotch Creative LLC
-      </div>
+       | <span class="text-xs text-gray-400 ml-2">v<span class="app-version-display"></span></span></div>
     </footer>
 
     <div
@@ -713,5 +713,6 @@
         &times;
       </button>
     </div>
-  </body>
+    <script type="module" src="./src/version.js"></script>
+</body>
 </html>

--- a/src/version.js
+++ b/src/version.js
@@ -1,0 +1,6 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const versionElements = document.querySelectorAll('.app-version-display');
+    versionElements.forEach(el => {
+        el.textContent = __APP_VERSION__;
+    });
+});

--- a/terms.html
+++ b/terms.html
@@ -68,7 +68,8 @@
     <footer class="bg-white shadow-md mt-8">
         <div class="container mx-auto px-6 py-3 text-center text-gray-500">
             &copy; 2025 Splotch | <a href="/terms.html" class="text-splotch-red hover:underline">Terms & FAQ</a>
-        </div>
+         | <span class="text-xs text-gray-400 ml-2">v<span class="app-version-display"></span></span></div>
     </footer>
+  <script type="module" src="./src/version.js"></script>
 </body>
 </html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,8 +3,15 @@ import { resolve } from 'path';
 import tailwindcss from '@tailwindcss/postcss';
 import autoprefixer from 'autoprefixer';
 import basicSsl from '@vitejs/plugin-basic-ssl';
+import fs from 'fs';
+
+const packageJson = JSON.parse(fs.readFileSync('./package.json'));
+process.env.VITE_APP_VERSION = packageJson.version;
 
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(packageJson.version)
+  },
   plugins: [
     basicSsl()
   ],


### PR DESCRIPTION
This PR adds a version number to the footer of all relevant HTML pages so that the current version can be tracked while viewing the site. The version is pulled from `package.json` and injected during the Vite build process.

---
*PR created automatically by Jules for task [10477006711349362475](https://jules.google.com/task/10477006711349362475) started by @LokiMetaSmith*