### PR TITLE
Fix missing email in WebAuthn JWT payload

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -2086,7 +2086,11 @@ async function startServer(
         const { verified } = verification;
         if (verified) {
           const { privateKey, kid } = getCurrentSigningKey();
-          const token = jwt.sign({ username: user.username }, privateKey, { algorithm: 'RS256', expiresIn: '1h', header: { kid } });
+          const payload = { username: user.username };
+          if (user.email) {
+              payload.email = user.email;
+          }
+          const token = jwt.sign(payload, privateKey, { algorithm: 'RS256', expiresIn: '1h', header: { kid } });
           res.json({ verified, token });
         } else {
           res.json({ verified });


### PR DESCRIPTION
Fixes an issue where WebAuthn users were incorrectly getting 403 Forbidden errors when accessing admin routes due to missing `email` in the JWT payload.

---
*PR created automatically by Jules for task [5529171896116325625](https://jules.google.com/task/5529171896116325625) started by @LokiMetaSmith*