### PR TITLE
fix(server): gracefully handle CSRF token missing/mismatch errors with 403

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -2301,6 +2301,12 @@ async function startServer(
             return res.status(400).json({ error: err.message });
         }
 
+        // Handle CSRF errors
+        if (err.message === 'CSRF token missing' || err.message === 'CSRF token mismatch') {
+            logger.warn(`[SECURITY] ${err.message} from ${req.ip}`);
+            return res.status(403).json({ error: err.message });
+        }
+
         logger.error('[SERVER] Unhandled Error:', err);
 
         // Hide stack trace in production (and generally in API responses)

--- a/server/tests/security_error_handling.test.js
+++ b/server/tests/security_error_handling.test.js
@@ -135,4 +135,25 @@ describe('Security: Error Handling and Information Leakage', () => {
 
     expect(res.body.message).toEqual('An unexpected error occurred.');
   });
+
+  it('should handle CSRF missing error gracefully with 403 instead of 500', async () => {
+    const agent = request.agent(app);
+
+    const res = await agent.post('/api/auth/login')
+      .send({ username: 'tester', password: 'password123' });
+
+    expect(res.statusCode).toEqual(403);
+    expect(res.body).toEqual({ error: 'CSRF token missing' });
+  });
+
+  it('should handle CSRF mismatch error gracefully with 403 instead of 500', async () => {
+    const agent = request.agent(app);
+
+    const res = await agent.post('/api/auth/login')
+      .set('X-CSRF-Token', 'invalid_token')
+      .send({ username: 'tester', password: 'password123' });
+
+    expect(res.statusCode).toEqual(403);
+    expect(res.body).toEqual({ error: 'CSRF token mismatch' });
+  });
 });


### PR DESCRIPTION
Fixes an issue where requests missing a CSRF token caused unhandled 500 errors in the server logs instead of a graceful 403 response.

---
*PR created automatically by Jules for task [7220945806500328595](https://jules.google.com/task/7220945806500328595) started by @LokiMetaSmith*