### PR TITLE
fix(server): handle null bot in telegram notifications

### DIFF
--- a/server/notificationLogic.js
+++ b/server/notificationLogic.js
@@ -10,6 +10,7 @@ const __dirname = path.dirname(__filename);
 const serverRoot = __dirname;
 
 export const sendNewOrderNotification = async (bot, db, orderId) => {
+    if (!bot || !bot.telegram) return;
     const CHANNEL_ID = getSecret('TELEGRAM_CHANNEL_ID');
     if (!CHANNEL_ID) return;
 
@@ -84,6 +85,7 @@ ${statusChecklist}
 };
 
 export const updateOrderStatusNotification = async (bot, db, orderId, status) => {
+    if (!bot || !bot.telegram) return;
     const CHANNEL_ID = getSecret('TELEGRAM_CHANNEL_ID');
     if (!CHANNEL_ID) return;
 


### PR DESCRIPTION
Fixes unhandled TypeError in `notificationLogic.js` when the Telegram bot is null.

---
*PR created automatically by Jules for task [577350998119426002](https://jules.google.com/task/577350998119426002) started by @LokiMetaSmith*