### PR TITLE
fix: Dynamic Clipper JoinType for Edge Cut Slider

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1922,6 +1922,7 @@ function generateCutLine(polygons, rawOffset, rawLazyRadius = 0) {
   }
 
   let final_paths;
+  const joinType = offsetPx <= 0 ? ClipperLib.JoinType.jtMiter : ClipperLib.JoinType.jtRound;
 
   if (lazyRadiusPx > 0) {
     // 1. Dilate to bridge gaps
@@ -1949,7 +1950,7 @@ function generateCutLine(polygons, rawOffset, rawLazyRadius = 0) {
     final_paths = new ClipperLib.Paths();
     co3.AddPaths(
       shrunk_paths,
-      ClipperLib.JoinType.jtRound,
+      joinType,
       ClipperLib.EndType.etClosedPolygon,
     );
     co3.Execute(final_paths, Math.round(offsetPx * scale));
@@ -1959,7 +1960,7 @@ function generateCutLine(polygons, rawOffset, rawLazyRadius = 0) {
     final_paths = new ClipperLib.Paths();
     co.AddPaths(
       scaledPolygons,
-      ClipperLib.JoinType.jtRound,
+      joinType,
       ClipperLib.EndType.etClosedPolygon,
     );
     co.Execute(final_paths, Math.round(offsetPx * scale));

--- a/tests/canvas-filters.test.js
+++ b/tests/canvas-filters.test.js
@@ -13,6 +13,7 @@ describe('Canvas Utils - drawImageWithFilters', () => {
             save: jest.fn(),
             restore: jest.fn(),
             drawImage: jest.fn(),
+            translate: jest.fn(),
             // Mock the property 'filter' with a setter to spy on it
             _filter: 'none',
             set filter(val) { this._filter = val; },


### PR DESCRIPTION
Updates the smart cutline polygon generation logic to properly process inward and outward offsets.
- Uses `jtMiter` (sharp corners) when negative offsets are applied, allowing the algorithm to cleanly trace the image bounds.
- Retains `jtRound` (rounded corners) for positive offsets.
- Fixed a testing suite bug regarding `ctxMock.translate` missing in `canvas-filters.test.js`.

---
*PR created automatically by Jules for task [7927980545313675304](https://jules.google.com/task/7927980545313675304) started by @LokiMetaSmith*