### PR TITLE
Fix edge detection sliders (lazy lasso & magic edge) and add E2E tests

### DIFF
--- a/playwright_tests/regression_cutline_slider.spec.js
+++ b/playwright_tests/regression_cutline_slider.spec.js
@@ -1,0 +1,30 @@
+import { test, expect } from './test-setup.js';
+import fs from 'fs';
+import path from 'path';
+
+const TEST_IMAGE_PATH = 'favicon.png';
+
+test('Cutline Slider features - Magic Edge / Offset / Lazy Lasso', async ({ page }) => {
+    await page.goto('/');
+
+    const fileInput = page.locator('#file');
+    await page.waitForTimeout(1000);
+    await fileInput.setInputFiles(TEST_IMAGE_PATH);
+
+    await expect(page.locator('.message-content').last()).toContainText('Image loaded successfully', { timeout: 10000 });
+
+    // By default, advanced controls are hidden. "Magic Edge" slider is visible instead of Cutline Offset.
+    const magicEdgeSlider = page.locator('#cutlineOffsetSlider');
+    await expect(magicEdgeSlider).toBeVisible();
+
+    const lazyLassoSlider = page.locator('#lazyLassoSlider');
+    await expect(lazyLassoSlider).not.toBeVisible();
+
+    // Unlock advanced features
+    await page.evaluate(() => document.dispatchEvent(new CustomEvent('easterEggUnlocked')));
+
+    // Now Cutline Offset and Lazy Lasso should be visible
+    await expect(magicEdgeSlider).toBeVisible(); // This slider changes meaning but keeps ID
+    await expect(lazyLassoSlider).toBeVisible();
+
+});

--- a/src/index.js
+++ b/src/index.js
@@ -408,7 +408,8 @@ async function BootStrap() {
 
       // Magic Edge behavior when advanced controls are hidden
       if (!easterEggUnlocked) {
-        currentLassoRadius = Math.max(0, Math.floor(cutlineOffset * 0.5));
+        // Map 1-to-1 to lazy lasso
+        currentLassoRadius = Math.max(0, Math.floor(Math.abs(cutlineOffset)));
         if (lazyLassoSlider) {
           lazyLassoSlider.value = currentLassoRadius;
           if (lazyLassoValueDisplay) {
@@ -3052,9 +3053,13 @@ function handleGenerateCutline(skipPrompt = false) {
 
         const ppi = selectedResolution ? selectedResolution.ppi : 300;
         // Calculate 2mm in pixels for max hole size
-        const maxAllowedHoleSize = (2 / 25.4) * ppi;
+        let maxAllowedHoleSize = (2 / 25.4) * ppi;
         // Calculate 0.5mm in pixels for min hole size (noise floor)
         const minAllowedHoleSize = (0.5 / 25.4) * ppi;
+
+        if (lazyLassoRadius >= 50) {
+            maxAllowedHoleSize = -1;
+        }
 
         significantContours = filterInternalContours(
           significantContours,


### PR DESCRIPTION
Fix edge detection sliders by removing inner cuts when lazy lasso hits 50 and improving magic edge calculation. Added regression e2e tests.

---
*PR created automatically by Jules for task [10563492670167613654](https://jules.google.com/task/10563492670167613654) started by @LokiMetaSmith*