### PR TITLE
Fix infinite retry loop on OAuth auth failure in email worker

### DIFF
--- a/server/workers/emailWorker.js
+++ b/server/workers/emailWorker.js
@@ -30,6 +30,12 @@ export const startEmailWorker = (oauth2Client, emailSender = sendEmail, db = nul
                         logger.error('[WORKER] Failed to clear invalid google_refresh_token:', dbErr);
                     }
                 }
+                return; // Do not retry if the token is revoked
+            }
+
+            if (error.message === 'No access, refresh token, API key or refresh handler callback is set.') {
+                logger.warn('[WORKER] No Google OAuth2 credentials. Cannot send email.');
+                return; // Do not retry if there are no credentials
             }
 
             throw error; // Let BullMQ handle retries


### PR DESCRIPTION
When the email worker encountered missing Google OAuth credentials ("No access, refresh token...") or explicitly encountered a revoked token ("invalid_grant"), it logged a warning but continued to throw the error to BullMQ. This triggered continuous retry loops for unrecoverable authentication errors. This change catches these specific auth errors and returns early instead of re-throwing, effectively stopping the infinite retry queue behavior.

---
*PR created automatically by Jules for task [9845339701658427430](https://jules.google.com/task/9845339701658427430) started by @LokiMetaSmith*