### PR TITLE
Fix auto-generation of contoured edges when offset is negative

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -408,7 +408,7 @@ async function BootStrap() {
 
       // If the user goes negative, and they haven't explicitly generated a smart edge
       // yet (meaning they have the default 4-point rectangle), auto-generate it.
-      if (cutlineOffset < 0 && rasterCutlinePoly && rasterCutlinePoly.length === 1 && rasterCutlinePoly[0].length === 4 && hasImage) {
+      if (cutlineOffset < 0 && rasterCutlinePoly && rasterCutlinePoly.length === 1 && rasterCutlinePoly[0].length === 4 && originalImage) {
         handleGenerateCutline(true); // pass true for skipToast
         return; // handleGenerateCutline will trigger the redraw
       }


### PR DESCRIPTION
Fixes a bug where negative values on the "Magic Edge" cutline offset slider failed to automatically generate the contoured smart cutline. The bug was caused by a conditional check in `src/index.js` referencing an undefined `hasImage` variable instead of the correctly initialized `originalImage` variable.

---
*PR created automatically by Jules for task [5424265186740793187](https://jules.google.com/task/5424265186740793187) started by @LokiMetaSmith*