### PR TITLE
Fix Cut Type toggle interaction

### DIFF
--- a/index.html
+++ b/index.html
@@ -441,9 +441,9 @@
               <label for="cutTypeToggle" class="flex items-center cursor-pointer space-x-2">
                 <span class="text-xs font-bold text-gray-600">Edge</span>
                 <div class="relative flex items-center">
-                  <input type="checkbox" id="cutTypeToggle" class="opacity-0 w-0 h-0 absolute peer pointer-events-none" role="switch" aria-label="Toggle Cut Type">
-                  <div class="block bg-gray-600 w-10 h-6 rounded-full peer-focus:ring-2 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 transition-shadow pointer-events-none"></div>
-                  <div class="dot absolute left-1 bg-white w-4 h-4 rounded-full transition peer-checked:translate-x-full peer-checked:bg-teal-500 pointer-events-none"></div>
+                  <input type="checkbox" id="cutTypeToggle" class="sr-only peer" role="switch" aria-label="Toggle Cut Type">
+                  <div class="block bg-gray-600 w-10 h-6 rounded-full peer-focus:ring-2 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 transition-shadow"></div>
+                  <div class="dot absolute left-1 bg-white w-4 h-4 rounded-full transition peer-checked:translate-x-full peer-checked:bg-teal-500"></div>
                 </div>
                 <span class="text-xs font-bold text-gray-600">Contour</span>
               </label>


### PR DESCRIPTION
Fixes the "Cut Type" toggle button in the frontend which previously didn't respond to clicks. Click events on the slider components were failing to trigger the state change on the underlying hidden checkbox.

---
*PR created automatically by Jules for task [13565891909434898549](https://jules.google.com/task/13565891909434898549) started by @LokiMetaSmith*