### PR TITLE
chore: fix jest out of memory crashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "test": "pnpm run test:unit && pnpm run test:e2e",
-    "test:unit": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
+    "test:unit": "NODE_OPTIONS='--max-old-space-size=4096' node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --forceExit --workerIdleMemoryLimit=512MB",
     "test:server": "cd server && pnpm test",
     "test:e2e": "playwright test",
     "test:e2e:real": "playwright test --config playwright.real.config.js",

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "main": "server.js",
   "type": "module",
   "scripts": {
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
+    "test": "NODE_OPTIONS='--max-old-space-size=4096' node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --forceExit --workerIdleMemoryLimit=512MB",
     "start": "node index.js",
     "build": "pnpm install"
   },


### PR DESCRIPTION
Fix jest OOM issues during unit testing by adding specific Node.js memory limit flags.

---
*PR created automatically by Jules for task [6535523115594339295](https://jules.google.com/task/6535523115594339295) started by @LokiMetaSmith*