### PR TITLE
fix(csp): add square font domains to font-src

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -651,10 +651,12 @@ async function startServer(
                 'default-src': "'self'",
                 'script-src': "'self' https://cdn.jsdelivr.net https://*.squarecdn.com https://sandbox.web.squarecdn.com",
                 'style-src': "'self' 'unsafe-inline' https://fonts.googleapis.com https://*.squarecdn.com https://sandbox.web.squarecdn.com",
-                'font-src': "'self' https://fonts.gstatic.com https://*.squarecdn.com https://d1g145x70srn7h.cloudfront.net",
+                'font-src': "'self' https://fonts.gstatic.com https://*.squarecdn.com https://cash-f.squarecdn.com https://square-fonts-production-f.squarecdn.com https://d1g145x70srn7h.cloudfront.net",
                 'img-src': "'self' data: blob: https://*.squarecdn.com https://sandbox.web.squarecdn.com",
                 'connect-src': "'self' https://*.squarecdn.com https://*.squareup.com https://*.squareupsandbox.com https://*.sentry.io",
-                'frame-src': "'self' https://*.squarecdn.com https://sandbox.web.squarecdn.com"
+                'frame-src': "'self' https://*.squarecdn.com https://sandbox.web.squarecdn.com",
+                'worker-src': "'self' blob: https://cdn.jsdelivr.net",
+                'child-src': "'self' blob: https://cdn.jsdelivr.net"
             }
         }
     }));


### PR DESCRIPTION
- Added `https://cash-f.squarecdn.com` and `https://square-fonts-production-f.squarecdn.com` to the CSP `font-src` directive in `server/server.js`.
- Added `worker-src` and `child-src` to allow Web Workers to load scripts from `cdn.jsdelivr.net` and `blob:` URLs, fixing a `NetworkError` encountered during Playwright tests.

---
*PR created automatically by Jules for task [8643318886191564428](https://jules.google.com/task/8643318886191564428) started by @LokiMetaSmith*