### PR TITLE
fix: add pnpm installation checks to start scripts

### DIFF
--- a/start.ps1
+++ b/start.ps1
@@ -1,3 +1,10 @@
+# Check if pnpm is installed
+if (-not (Get-Command "pnpm" -ErrorAction SilentlyContinue)) {
+    Write-Host "Error: pnpm is not installed." -ForegroundColor Red
+    Write-Host "Please install it by running: npm install -g pnpm" -ForegroundColor Yellow
+    exit 1
+}
+
 Write-Host "Installing root dependencies..."
 pnpm install
 

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Check if pnpm is installed
+if ! command -v pnpm &> /dev/null
+then
+    echo "Error: pnpm is not installed."
+    echo "Please install it by running: npm install -g pnpm"
+    exit 1
+fi
+
 echo "Installing root dependencies..."
 pnpm install
 


### PR DESCRIPTION
Adds a check to `start.sh` and `start.ps1` to ensure `pnpm` is installed before attempting to start up the dev environments, to resolve confusing cascaded errors when it's missing.

---
*PR created automatically by Jules for task [16410520748845398717](https://jules.google.com/task/16410520748845398717) started by @LokiMetaSmith*