### PR TITLE
Fix pnpm ignored builds warning

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,9 @@
 allowBuilds:
-  '@parcel/watcher': set this to true or false
-  bcrypt: set this to true or false
-  core-js: set this to true or false
-  esbuild: set this to true or false
-  nodent-runtime: set this to true or false
-  unrs-resolver: set this to true or false
+  - "@parcel/watcher"
+  - "bcrypt"
+  - "core-js"
+  - "esbuild"
+  - "nodent-runtime"
+  - "unrs-resolver"
+  - "@sentry-internal/node-cpu-profiler"
+  - "msgpackr-extract"


### PR DESCRIPTION
Fixes the `[ERR_PNPM_IGNORED_BUILDS]` warning logged when running `pnpm install` in the project root. This occurred because pnpm v9+ requires the `allowBuilds` option in `pnpm-workspace.yaml` to be a strict YAML array, not a key-value object map. The startup scripts (`start.sh`, `start.ps1`) would fail because `pnpm install` would exit with code 1 upon encountering these "ignored" builds. The fix updates the root `pnpm-workspace.yaml` file to appropriately whitelist the used build scripts.

---
*PR created automatically by Jules for task [12552369136578803146](https://jules.google.com/task/12552369136578803146) started by @LokiMetaSmith*