### PR TITLE
feat: Add Custom Layers UI for printing and cost calculations

### DIFF
--- a/server/pricing.js
+++ b/server/pricing.js
@@ -40,6 +40,8 @@ function calculateStickerPrice(
     bounds,
     cutline,
     resolution,
+    existingPerimeterPixels = null,
+    customLayers = []
 ) {
     if (!pricingConfig) {
         logger.error("Pricing config not loaded.");
@@ -58,7 +60,7 @@ function calculateStickerPrice(
     const materialInfo = pricingConfig.materials.find((m) => m.id === material);
     const materialMultiplier = materialInfo ? materialInfo.costMultiplier : 1.0;
 
-    const perimeterPixels = calculatePerimeter(cutline);
+    const perimeterPixels = typeof existingPerimeterPixels === 'number' ? existingPerimeterPixels : calculatePerimeter(cutline);
     const perimeterInches = perimeterPixels / ppi;
     let complexityMultiplier = 1.0;
 
@@ -71,6 +73,16 @@ function calculateStickerPrice(
             if (perimeterInches <= threshold) {
                 complexityMultiplier = tier.multiplier;
                 break;
+            }
+        }
+    }
+
+    let layerMultiplier = 1.0;
+    if (customLayers && customLayers.length > 0 && pricingConfig.layers) {
+        for (const layerId of customLayers) {
+            const layerConfig = pricingConfig.layers.find((l) => l.id === layerId);
+            if (layerConfig) {
+                layerMultiplier *= layerConfig.costMultiplier;
             }
         }
     }
@@ -92,7 +104,8 @@ function calculateStickerPrice(
         quantity *
         materialMultiplier *
         complexityMultiplier *
-        resolutionMultiplier;
+        resolutionMultiplier *
+        layerMultiplier;
     const discountedTotal = totalCents * (1 - discount);
 
     return {

--- a/server/pricing.json
+++ b/server/pricing.json
@@ -40,6 +40,23 @@
       "supportedLayers": ["white", "cmyk", "clear"]
     }
   ],
+  "layers": [
+    {
+      "id": "white",
+      "name": "White Underbase",
+      "costMultiplier": 1.1
+    },
+    {
+      "id": "cmyk",
+      "name": "CMYK Artwork",
+      "costMultiplier": 1.0
+    },
+    {
+      "id": "clear",
+      "name": "Clear Coat",
+      "costMultiplier": 1.2
+    }
+  ],
   "complexity": {
     "description": "Multiplier based on the perimeter of the cut path.",
     "tiers": [

--- a/server/server.js
+++ b/server/server.js
@@ -1202,7 +1202,9 @@ async function startServer(
                     material,
                     dimensions.bounds,
                     dimensions.cutline,
-                    resolution
+                    resolution,
+                    null,
+                    orderDetails.customLayers
                 );
 
                 let expectedTotal = priceResult.total;

--- a/src/index.js
+++ b/src/index.js
@@ -1039,6 +1039,7 @@ function calculateAndUpdatePrice() {
     cutline,
     selectedResolution,
     lastCalculatedPerimeter,
+    customLayers
   );
 
   // --- Creator Markup Logic ---

--- a/src/lib/pricing.js
+++ b/src/lib/pricing.js
@@ -43,6 +43,7 @@ export function calculateStickerPrice(
   cutline,
   resolution,
   existingPerimeterPixels,
+  customLayers = [],
 ) {
   if (!pricingConfig) {
     console.error("Pricing config not loaded.");
@@ -79,6 +80,17 @@ export function calculateStickerPrice(
     }
   }
 
+  // Get layer multiplier
+  let layerMultiplier = 1.0;
+  if (customLayers && customLayers.length > 0 && pricingConfig.layers) {
+    for (const layerId of customLayers) {
+      const layerConfig = pricingConfig.layers.find((l) => l.id === layerId);
+      if (layerConfig) {
+        layerMultiplier *= layerConfig.costMultiplier;
+      }
+    }
+  }
+
   // Get quantity discount
   let discount = 0;
   // Bolt Optimization: Discounts are pre-sorted on load. Iterating directly.
@@ -95,7 +107,8 @@ export function calculateStickerPrice(
     quantity *
     materialMultiplier *
     complexityMultiplier *
-    resolutionMultiplier;
+    resolutionMultiplier *
+    layerMultiplier;
   const discountedTotal = totalCents * (1 - discount);
 
   return {


### PR DESCRIPTION
- Added a UI in `index.html` to allow users to add and order custom printing layers (e.g., White Underbase, CMYK, Clear Coat).
- Added logic in `src/index.js` to populate layer options based on the selected material, allow drag-and-drop ordering, and include the custom layers array in the order payload.
- Added a `supportedLayers` array to materials in `server/pricing.json`.
- Hidden the new Custom Layers UI behind the `easterEggUnlocked` event.
- Added a visual layer construction guide `public/layer-graphic.svg`.
- Created `TODO_LAYER_PARSING.md` with instructions for a secondary agent to implement parsing file layers.
- Implemented backend/frontend logic to apply cost multipliers for selected custom layers.