### PR TITLE
feat: Implement layer UI functionality with text layer and draggable tabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@simplewebauthn/browser": "^13.1.2",
         "@simplewebauthn/server": "^13.1.2",
         "bcrypt": "^6.0.0",
+        "clipper-lib": "^6.4.2",
         "commander": "^14.0.2",
         "compression": "^1.8.1",
         "cookie-parser": "^1.4.7",
@@ -36,6 +37,7 @@
         "multer": "^2.0.1",
         "nodemailer": "^7.0.5",
         "pdf-poppler": "^0.2.3",
+        "sortablejs": "^1.15.7",
         "square": "^43.0.1",
         "svg-parser": "^2.0.4",
         "svg-path-properties": "^2.0.0",
@@ -7074,6 +7076,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/clipper-lib": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/clipper-lib/-/clipper-lib-6.4.2.tgz",
+      "integrity": "sha512-knglhjQX5ihNj/XCIs6zCHrTemdvHY3LPZP9XB2nq2/3igyYMFueFXtfp84baJvEE+f8pO1ZS4UVeEgmLnAprQ==",
+      "license": "BSL"
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -16091,6 +16099,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/sortablejs": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.7.tgz",
+      "integrity": "sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A==",
+      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "multer": "^2.0.1",
     "nodemailer": "^7.0.5",
     "pdf-poppler": "^0.2.3",
+    "sortablejs": "^1.15.7",
     "square": "^43.0.1",
     "svg-parser": "^2.0.4",
     "svg-path-properties": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       pdf-poppler:
         specifier: ^0.2.3
         version: 0.2.3
+      sortablejs:
+        specifier: ^1.15.7
+        version: 1.15.7
       square:
         specifier: ^43.0.1
         version: 43.2.1
@@ -4995,6 +4998,9 @@ packages:
   sort-on@6.1.1:
     resolution: {integrity: sha512-PB8pVvXAoRBijBCvuKJnmo06D8mSnQlLij0abfB2VdOpfFm29sPGYD4ft2prUPo1AZXTnkn3pP48AppRWyMkrw==}
     engines: {node: '>=18'}
+
+  sortablejs@1.15.7:
+    resolution: {integrity: sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -11198,6 +11204,8 @@ snapshots:
   sort-on@6.1.1:
     dependencies:
       dot-prop: 9.0.0
+
+  sortablejs@1.15.7: {}
 
   source-map-js@1.2.1: {}
 

--- a/tests/canvas-utils.test.js
+++ b/tests/canvas-utils.test.js
@@ -14,6 +14,7 @@ describe('Canvas Utils: drawRuler', () => {
             lineTo: jest.fn(),
             stroke: jest.fn(),
             fillText: jest.fn(),
+            measureText: jest.fn(() => ({ width: 10 })),
             strokeStyle: '',
             fillStyle: '',
             font: '',


### PR DESCRIPTION
This PR adds a sortable layer tab UI that is hidden behind the `easterEggUnlocked` feature flag. The dimension controls (sizes input, in/mm toggle) have been grouped under the Base Design layer. Text controls have been moved and are now created as a "Text" layer. This layer operates like a custom layer and can be dragged around using the newly added `sortablejs` dependency to re-arrange the visual z-index.

---
*PR created automatically by Jules for task [5177504893437242710](https://jules.google.com/task/5177504893437242710) started by @LokiMetaSmith*