### PR TITLE
Hide starter templates from UI when not in easter egg mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
           tabindex="-1"
         >
           <!-- STARTER TEMPLATES -->
-          <div class="field mb-6 border-b border-gray-200 pb-4">
+          <div class="field mb-6 border-b border-gray-200 pb-4" id="starterTemplatesSection" style="display: none;">
             <label class="label text-sm font-medium text-gray-700 block mb-2">Starter Templates:</label>
             <div class="flex flex-wrap gap-2">
               <button type="button" id="templateBlankBtn" class="template-btn active px-4 py-2 bg-indigo-100 text-indigo-700 rounded-md font-semibold text-sm border border-indigo-200 hover:bg-indigo-200 transition-colors focus:ring-2 focus:ring-indigo-500 outline-none" data-template="blank">Blank Canvas</button>

--- a/src/index.js
+++ b/src/index.js
@@ -957,6 +957,7 @@ async function BootStrap() {
       );
       const lazyLassoContainer = document.getElementById("lazyLassoContainer");
       const generateCutlineBtn = document.getElementById("generateCutlineBtn");
+      const starterTemplatesSection = document.getElementById("starterTemplatesSection");
       layerControlsContainer = document.getElementById("layer-controls-container");
 
       if (grayBtn) {
@@ -996,6 +997,10 @@ async function BootStrap() {
 
       if (layerControlsContainer) {
         layerControlsContainer.style.display = "block";
+      }
+
+      if (starterTemplatesSection) {
+        starterTemplatesSection.style.display = "block";
       }
 
       updateEditingButtonsState(isDisabled);


### PR DESCRIPTION
Hide starter templates from UI when not in easter egg mode

---
*PR created automatically by Jules for task [6947553021126484516](https://jules.google.com/task/6947553021126484516) started by @LokiMetaSmith*