### PR TITLE
Increase font size of Sticker Options label and sticker ruler

### DIFF
--- a/index.html
+++ b/index.html
@@ -808,7 +808,7 @@
           <!-- Sticker Options -->
           <div class="space-y-4">
             <h3
-              class="text-lg font-semibold text-splotch-navy pt-2"
+              class="text-xl font-semibold text-splotch-navy pt-2"
               style="font-family: var(--font-modak)"
             >
               Sticker Options

--- a/playwright_tests/canvas-ruler.spec.js
+++ b/playwright_tests/canvas-ruler.spec.js
@@ -30,7 +30,7 @@ test.describe('Canvas Ruler', () => {
         await fileInput.setInputFiles(testImagePath);
 
         // 3. Wait for canvas to be populated and ruler drawn
-        await expect(page.locator('.message-content')).toContainText('Image loaded successfully');
+        await expect(page.locator('#toast-container')).toContainText('Base image loaded successfully');
 
         // 4. Verify the ruler is visually present via screenshot
         // We can't easily query the canvas content, but we can verify the canvas exists and take a screenshot

--- a/src/lib/canvas-utils.js
+++ b/src/lib/canvas-utils.js
@@ -75,14 +75,17 @@ export function drawRuler(ctx, bounds, offset = { x: 0, y: 0 }, ppi, isMetric) {
         }
     }
 
-    const fontSize = 12;
-    const tickScale = 1;
+    const ppiScale = ppi / 96;
+    const fontSize = Math.max(12, Math.round(12 * ppiScale));
+    const tickScale = Math.max(1, ppiScale);
+    const lineWidth = Math.max(1, Math.round(1 * ppiScale));
+    const labelSpacingOffset = 2 * tickScale;
 
     ctx.save();
     ctx.strokeStyle = "rgba(0, 0, 0, 0.5)";
     ctx.fillStyle = "rgba(0, 0, 0, 0.8)";
     ctx.font = `${fontSize}px Arial`;
-    ctx.lineWidth = 1;
+    ctx.lineWidth = lineWidth;
 
     // Bolt Optimization: Batch drawing calls to reduce overhead
     // Top ruler
@@ -100,7 +103,7 @@ export function drawRuler(ctx, bounds, offset = { x: 0, y: 0 }, ppi, isMetric) {
         if (isMajorMark && i > 0) {
             const labelValue = (i / ticksPerMajor) * labelMultiplier;
             const label = `${Number.isInteger(labelValue) ? labelValue : labelValue.toFixed(1)}${labelSuffix}`;
-            ctx.fillText(label, x + 3, y - markHeight - 2);
+            ctx.fillText(label, x + 3 * tickScale, y - markHeight - labelSpacingOffset);
         }
     }
     ctx.stroke();
@@ -120,7 +123,7 @@ export function drawRuler(ctx, bounds, offset = { x: 0, y: 0 }, ppi, isMetric) {
         if (isMajorMark && i > 0) {
             const labelValue = (i / ticksPerMajor) * labelMultiplier;
             const label = `${Number.isInteger(labelValue) ? labelValue : labelValue.toFixed(1)}${labelSuffix}`;
-            ctx.fillText(label, x - markWidth - 5 - (ctx.measureText(label).width), y + (fontSize / 3));
+            ctx.fillText(label, x - markWidth - (5 * tickScale) - (ctx.measureText(label).width), y + (fontSize / 3));
         }
     }
     ctx.stroke();

--- a/tests/canvas-utils.test.js
+++ b/tests/canvas-utils.test.js
@@ -81,9 +81,12 @@ describe('Canvas Utils: drawRuler', () => {
     });
 
     describe('Dynamic Scale Constants and Units', () => {
-        const checkConstantScale = (mockCtx) => {
-            expect(mockCtx.font).toBe('12px Arial');
-            expect(mockCtx.lineWidth).toBe(1);
+        const checkConstantScale = (mockCtx, ppi) => {
+            const ppiScale = ppi / 96;
+            const fontSize = Math.max(12, Math.round(12 * ppiScale));
+            const lineWidth = Math.max(1, Math.round(1 * ppiScale));
+            expect(mockCtx.font).toBe(`${fontSize}px Arial`);
+            expect(mockCtx.lineWidth).toBe(lineWidth);
         };
 
         it('should use mils for imperial images < 2 inches', () => {
@@ -91,7 +94,7 @@ describe('Canvas Utils: drawRuler', () => {
             const bounds = { width: 1.5 * ppi, height: 1.5 * ppi }; // 1.5 inches
             drawRuler(mockCtx, bounds, {x:0, y:0}, ppi, false);
 
-            checkConstantScale(mockCtx);
+            checkConstantScale(mockCtx, ppi);
             expect(mockCtx.fillText).toHaveBeenCalledWith(expect.stringContaining('mil'), expect.any(Number), expect.any(Number));
         });
 
@@ -100,7 +103,7 @@ describe('Canvas Utils: drawRuler', () => {
             const bounds = { width: 10 * ppi, height: 10 * ppi }; // 10 inches
             drawRuler(mockCtx, bounds, {x:0, y:0}, ppi, false);
 
-            checkConstantScale(mockCtx);
+            checkConstantScale(mockCtx, ppi);
             expect(mockCtx.fillText).toHaveBeenCalledWith(expect.stringContaining('in'), expect.any(Number), expect.any(Number));
         });
 
@@ -109,7 +112,7 @@ describe('Canvas Utils: drawRuler', () => {
             const bounds = { width: 30 * ppi, height: 30 * ppi }; // 30 inches
             drawRuler(mockCtx, bounds, {x:0, y:0}, ppi, false);
 
-            checkConstantScale(mockCtx);
+            checkConstantScale(mockCtx, ppi);
             expect(mockCtx.fillText).toHaveBeenCalledWith(expect.stringContaining('ft'), expect.any(Number), expect.any(Number));
         });
 
@@ -118,7 +121,7 @@ describe('Canvas Utils: drawRuler', () => {
             const bounds = { width: (0.5 / 25.4) * ppi, height: (0.5 / 25.4) * ppi }; // 0.5 mm
             drawRuler(mockCtx, bounds, {x:0, y:0}, ppi, true);
 
-            checkConstantScale(mockCtx);
+            checkConstantScale(mockCtx, ppi);
             expect(mockCtx.fillText).toHaveBeenCalledWith(expect.stringContaining('µm'), expect.any(Number), expect.any(Number));
         });
 
@@ -127,7 +130,7 @@ describe('Canvas Utils: drawRuler', () => {
             const bounds = { width: (15 / 25.4) * ppi, height: (15 / 25.4) * ppi }; // 15 mm
             drawRuler(mockCtx, bounds, {x:0, y:0}, ppi, true);
 
-            checkConstantScale(mockCtx);
+            checkConstantScale(mockCtx, ppi);
             expect(mockCtx.fillText).toHaveBeenCalledWith(expect.stringContaining('mm'), expect.any(Number), expect.any(Number));
         });
 
@@ -136,7 +139,7 @@ describe('Canvas Utils: drawRuler', () => {
             const bounds = { width: (500 / 25.4) * ppi, height: (500 / 25.4) * ppi }; // 500 mm
             drawRuler(mockCtx, bounds, {x:0, y:0}, ppi, true);
 
-            checkConstantScale(mockCtx);
+            checkConstantScale(mockCtx, ppi);
             expect(mockCtx.fillText).toHaveBeenCalledWith(expect.stringContaining('mm'), expect.any(Number), expect.any(Number));
         });
 
@@ -145,7 +148,7 @@ describe('Canvas Utils: drawRuler', () => {
             const bounds = { width: (1500 / 25.4) * ppi, height: (1500 / 25.4) * ppi }; // 1500 mm
             drawRuler(mockCtx, bounds, {x:0, y:0}, ppi, true);
 
-            checkConstantScale(mockCtx);
+            checkConstantScale(mockCtx, ppi);
             expect(mockCtx.fillText).toHaveBeenCalledWith(expect.stringContaining('m'), expect.any(Number), expect.any(Number));
         });
     });


### PR DESCRIPTION
- Changed the `text-lg` class on the "Sticker Options" label to `text-xl` in `index.html`.
- Updated the `drawRuler` function in `src/lib/canvas-utils.js` to dynamically scale the ruler's font size based on the chosen PPI (pixels per inch), rather than keeping it a constant 12px. The tick scale and line width are also scaled proportionally.
- Updated `tests/canvas-utils.test.js` to correctly check for the dynamically scaled constants.
- Updated `playwright_tests/canvas-ruler.spec.js` where a string assertion was failing ("Image loaded successfully" was changed to "Base image loaded successfully" upstream).

---
*PR created automatically by Jules for task [4076439658081570996](https://jules.google.com/task/4076439658081570996) started by @LokiMetaSmith*