### PR TITLE
🎨 Palette: Add tooltips to technical terms

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-03-10 - Explicit Modal ARIA Attributes
 **Learning:** Custom HTML modal implementations (like `#login-modal` containers) require explicit `role="dialog"`, `aria-modal="true"`, and an `aria-labelledby` attribute pointing to the modal's title ID to ensure proper screen reader accessibility. Without these, screen readers may not announce the content appropriately as an active dialog box.
 **Action:** Always include `role="dialog"`, `aria-modal="true"`, and `aria-labelledby="[TitleID]"` on dynamically toggled or custom-built modal containers.
+
+## 2026-07-23 - Explaining Technical Terms using Tooltips
+**Learning:** Using an `(i)` info icon next to technical labels (like "Lazy Lasso" or "Edge Sensitivity") is an excellent way to provide explanations through tooltips without cluttering the UI with permanent helper text. Placing the `data-tooltip` on the `(i)` icon rather than the input itself clarifies what is being explained.
+**Action:** When encountering potentially confusing or technical terminology in the interface, add an `(i)` icon with a `cursor-help` class and a `data-tooltip` containing a brief, clear explanation next to the corresponding label.

--- a/UX_TODO.md
+++ b/UX_TODO.md
@@ -18,7 +18,7 @@ This is a list of proposed UX improvements for the Print Shop interface, ordered
 - [ ] **Visual Feedback:** Add a loading spinner or progress bar to the [GENERATE SMART CUTLINE] button.
 - [ ] **Real-time Preview:** If possible, decouple the sliders to update the cutline in real-time as the user scrubs them.
 - [ ] **Information Architecture:** Group settings better (e.g. "Shape/Size" for Magic Edge, "Detail/Smoothing" for Sensitivity and Lasso).
-- [ ] **Tooltips:** Add (i) icons with tooltips explaining technical terms like "Lazy Lasso".
+- [x] **Tooltips:** Add (i) icons with tooltips explaining technical terms like "Lazy Lasso".
 - [ ] **Smart Presets:** Add preset buttons (Tight, Bubble, Smooth) for one-click configuration of edge and sensitivity sliders.
 - [ ] **Contrast Toggle:** Add a button to toggle the canvas background between light, dark, and transparent to help see edges better.
 - [ ] **Manual Node Editing (Advanced):** Allow users to click and drag specific points on the generated path to tweak the cutline.

--- a/index.html
+++ b/index.html
@@ -151,14 +151,47 @@
           tabindex="-1"
         >
           <!-- STARTER TEMPLATES -->
-          <div class="field mb-6 border-b border-gray-200 pb-4" id="starterTemplatesSection" style="display: none;">
-            <label class="label text-sm font-medium text-gray-700 block mb-2">Starter Templates:</label>
+          <div
+            class="field mb-6 border-b border-gray-200 pb-4"
+            id="starterTemplatesSection"
+            style="display: none"
+          >
+            <label class="label text-sm font-medium text-gray-700 block mb-2"
+              >Starter Templates:</label
+            >
             <div class="flex flex-wrap gap-2">
-              <button type="button" id="templateBlankBtn" class="template-btn active px-4 py-2 bg-indigo-100 text-indigo-700 rounded-md font-semibold text-sm border border-indigo-200 hover:bg-indigo-200 transition-colors focus:ring-2 focus:ring-indigo-500 outline-none" data-template="blank">Blank Canvas</button>
-              <button type="button" id="templateHelloBtn" class="template-btn px-4 py-2 bg-white text-gray-700 rounded-md font-semibold text-sm border border-gray-300 hover:bg-gray-100 transition-colors focus:ring-2 focus:ring-indigo-500 outline-none" data-template="hello_badge">Hello Badge</button>
-              <button type="button" id="templateThankYouBtn" class="template-btn px-4 py-2 bg-white text-gray-700 rounded-md font-semibold text-sm border border-gray-300 hover:bg-gray-100 transition-colors focus:ring-2 focus:ring-indigo-500 outline-none" data-template="thank_you">Thank You</button>
+              <button
+                type="button"
+                id="templateBlankBtn"
+                class="template-btn active px-4 py-2 bg-indigo-100 text-indigo-700 rounded-md font-semibold text-sm border border-indigo-200 hover:bg-indigo-200 transition-colors focus:ring-2 focus:ring-indigo-500 outline-none"
+                data-template="blank"
+              >
+                Blank Canvas
+              </button>
+              <button
+                type="button"
+                id="templateHelloBtn"
+                class="template-btn px-4 py-2 bg-white text-gray-700 rounded-md font-semibold text-sm border border-gray-300 hover:bg-gray-100 transition-colors focus:ring-2 focus:ring-indigo-500 outline-none"
+                data-template="hello_badge"
+              >
+                Hello Badge
+              </button>
+              <button
+                type="button"
+                id="templateThankYouBtn"
+                class="template-btn px-4 py-2 bg-white text-gray-700 rounded-md font-semibold text-sm border border-gray-300 hover:bg-gray-100 transition-colors focus:ring-2 focus:ring-indigo-500 outline-none"
+                data-template="thank_you"
+              >
+                Thank You
+              </button>
             </div>
-            <p class="text-xs text-gray-500 mt-2" style="font-family: var(--font-baumans)">Select a template to start with a predefined layout, or choose "Blank Canvas" to upload your own design.</p>
+            <p
+              class="text-xs text-gray-500 mt-2"
+              style="font-family: var(--font-baumans)"
+            >
+              Select a template to start with a predefined layout, or choose
+              "Blank Canvas" to upload your own design.
+            </p>
           </div>
 
           <!-- UPLOAD STICKER FILE -->
@@ -214,86 +247,98 @@
           <!-- Canvas & Layer Editor -->
           <div class="flex flex-col lg:flex-row gap-4 mb-6">
             <!-- Canvas for Image Editing -->
-            <div class="bg-gray-50 p-4 rounded-lg shadow-inner flex-grow min-w-0">
-              <div
-
-              id="canvas-container"
-              class="relative w-fit mx-auto outline-none"
-              contenteditable="true"
-              inputmode="none"
-              style="caret-color: transparent"
-            >
-              <canvas
-                id="imageCanvas"
-                width="500"
-                height="400"
-                class="block border-2 border-dashed border-gray-300 rounded-md bg-white"
-                style="background-image: linear-gradient(45deg, #ccc 25%, transparent 25%), linear-gradient(135deg, #ccc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #ccc 75%), linear-gradient(135deg, transparent 75%, #ccc 75%); background-size: 20px 20px; background-position: 0 0, 10px 0, 10px -10px, 0px 10px; background-color: white;"
-              >
-                Your browser does not support the HTML5 canvas tag.
-              </canvas>
-              <div
-                id="canvas-placeholder"
-                class="absolute inset-0 flex flex-col items-center justify-center select-none z-20 bg-white/60 backdrop-blur-sm rounded-lg cursor-pointer hover:bg-white/80 transition-colors focus-visible:ring-4 focus-visible:ring-splotch-teal focus-visible:outline-none focus-visible:ring-inset"
-                role="button"
-                tabindex="0"
-                aria-label="Upload an image by clicking or dragging and dropping"
-              >
-                <svg
-                  class="w-16 h-16 mb-2 text-gray-500 pointer-events-none"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  xmlns="http://www.w3.org/2000/svg"
-                  aria-hidden="true"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
-                  ></path>
-                </svg>
-                <p
-                  class="text-lg font-medium text-gray-600 pointer-events-none"
-                  style="font-family: var(--font-baumans)"
-                >
-                  Drag & Drop Image Here
-                </p>
-                <p
-                  class="text-sm text-gray-500 mt-1 pointer-events-none"
-                  style="font-family: var(--font-baumans)"
-                >
-                  or click to upload
-                </p>
-                <p
-                  class="text-xs text-splotch-teal font-bold mt-2 pointer-events-none animate-pulse"
-                  style="font-family: var(--font-baumans)"
-                >
-                  (Tip: Drag the mascot here to try it!)
-                </p>
-              </div>
-            </div>
-
-            <!-- Interactive Layer Tabs -->
             <div
-              id="layer-tabs"
-              class="flex justify-center gap-2 mt-4 transition-opacity duration-300"
-              style="display: none"
+              class="bg-gray-50 p-4 rounded-lg shadow-inner flex-grow min-w-0"
             >
-              <!-- Populated by JS -->
-            </div>
-            <p
-              id="designMarginNote"
-              class="text-xs text-splotch-red bg-white border border-red-200 rounded-full shadow-sm px-3 py-1.5 mx-auto mt-4 w-fit"
-              style="font-family: var(--font-baumans); display: none"
-              contenteditable="false"
-            >
-              Keep important elements 2-3mm from edge!
-            </p>
-            </div>
-            
+              <div
+                id="canvas-container"
+                class="relative w-fit mx-auto outline-none"
+                contenteditable="true"
+                inputmode="none"
+                style="caret-color: transparent"
+              >
+                <canvas
+                  id="imageCanvas"
+                  width="500"
+                  height="400"
+                  class="block border-2 border-dashed border-gray-300 rounded-md bg-white"
+                  style="
+                    background-image:
+                      linear-gradient(45deg, #ccc 25%, transparent 25%),
+                      linear-gradient(135deg, #ccc 25%, transparent 25%),
+                      linear-gradient(45deg, transparent 75%, #ccc 75%),
+                      linear-gradient(135deg, transparent 75%, #ccc 75%);
+                    background-size: 20px 20px;
+                    background-position:
+                      0 0,
+                      10px 0,
+                      10px -10px,
+                      0px 10px;
+                    background-color: white;
+                  "
+                >
+                  Your browser does not support the HTML5 canvas tag.
+                </canvas>
+                <div
+                  id="canvas-placeholder"
+                  class="absolute inset-0 flex flex-col items-center justify-center select-none z-20 bg-white/60 backdrop-blur-sm rounded-lg cursor-pointer hover:bg-white/80 transition-colors focus-visible:ring-4 focus-visible:ring-splotch-teal focus-visible:outline-none focus-visible:ring-inset"
+                  role="button"
+                  tabindex="0"
+                  aria-label="Upload an image by clicking or dragging and dropping"
+                >
+                  <svg
+                    class="w-16 h-16 mb-2 text-gray-500 pointer-events-none"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                    aria-hidden="true"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                    ></path>
+                  </svg>
+                  <p
+                    class="text-lg font-medium text-gray-600 pointer-events-none"
+                    style="font-family: var(--font-baumans)"
+                  >
+                    Drag & Drop Image Here
+                  </p>
+                  <p
+                    class="text-sm text-gray-500 mt-1 pointer-events-none"
+                    style="font-family: var(--font-baumans)"
+                  >
+                    or click to upload
+                  </p>
+                  <p
+                    class="text-xs text-splotch-teal font-bold mt-2 pointer-events-none animate-pulse"
+                    style="font-family: var(--font-baumans)"
+                  >
+                    (Tip: Drag the mascot here to try it!)
+                  </p>
+                </div>
+              </div>
 
+              <!-- Interactive Layer Tabs -->
+              <div
+                id="layer-tabs"
+                class="flex justify-center gap-2 mt-4 transition-opacity duration-300"
+                style="display: none"
+              >
+                <!-- Populated by JS -->
+              </div>
+              <p
+                id="designMarginNote"
+                class="text-xs text-splotch-red bg-white border border-red-200 rounded-full shadow-sm px-3 py-1.5 mx-auto mt-4 w-fit"
+                style="font-family: var(--font-baumans); display: none"
+                contenteditable="false"
+              >
+                Keep important elements 2-3mm from edge!
+              </p>
+            </div>
           </div>
 
           <!-- Basic Image Editing Controls -->
@@ -302,7 +347,9 @@
             class="flex flex-wrap justify-center items-center gap-4 my-6 p-4 border border-gray-200 rounded-md shadow-sm bg-slate-50"
           >
             <!-- Base Layer Controls -->
-            <div class="control-group-base flex flex-wrap justify-center items-center gap-4">
+            <div
+              class="control-group-base flex flex-wrap justify-center items-center gap-4"
+            >
               <button
                 type="button"
                 id="rotateLeftBtn"
@@ -436,88 +483,117 @@
                 </div>
               </div>
               <div
-            id="standard-sizes-controls"
-            class="w-full flex flex-wrap justify-center items-center gap-2 mt-4 mb-0"
-          >
-            <span class="text-sm font-medium text-gray-700 whitespace-nowrap"
-              >Set max dimension to:</span
-            >
-            <button
-              type="button"
-              class="size-btn"
-              data-size="1"
-              aria-label="Set max dimension to 1 inch"
-              data-tooltip="Set max dimension to 1 inch"
-              aria-pressed="false"
-            >
-              1"
-            </button>
-            <button
-              type="button"
-              class="size-btn"
-              data-size="2"
-              aria-label="Set max dimension to 2 inches"
-              data-tooltip="Set max dimension to 2 inches"
-              aria-pressed="false"
-            >
-              2"
-            </button>
-            <button
-              type="button"
-              class="size-btn"
-              data-size="3"
-              aria-label="Set max dimension to 3 inches"
-              data-tooltip="Set max dimension to 3 inches"
-              aria-pressed="false"
-            >
-              3"
-            </button>
-            <div class="ml-4 flex items-center">
-              <span class="text-sm mr-2" aria-hidden="true">in</span>
-              <label for="unitToggle" class="flex items-center cursor-pointer">
-                <div class="relative">
-                  <input
-                    type="checkbox"
-                    id="unitToggle"
-                    class="sr-only peer"
-                    role="switch"
-                    aria-label="Use Metric Units"
-                  />
-                  <div
-                    class="block bg-gray-600 w-14 h-8 rounded-full peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 transition-shadow"
-                  ></div>
-                  <div
-                    class="dot absolute left-1 top-1 bg-white w-6 h-6 rounded-full transition"
-                  ></div>
+                id="standard-sizes-controls"
+                class="w-full flex flex-wrap justify-center items-center gap-2 mt-4 mb-0"
+              >
+                <span
+                  class="text-sm font-medium text-gray-700 whitespace-nowrap"
+                  >Set max dimension to:</span
+                >
+                <button
+                  type="button"
+                  class="size-btn"
+                  data-size="1"
+                  aria-label="Set max dimension to 1 inch"
+                  data-tooltip="Set max dimension to 1 inch"
+                  aria-pressed="false"
+                >
+                  1"
+                </button>
+                <button
+                  type="button"
+                  class="size-btn"
+                  data-size="2"
+                  aria-label="Set max dimension to 2 inches"
+                  data-tooltip="Set max dimension to 2 inches"
+                  aria-pressed="false"
+                >
+                  2"
+                </button>
+                <button
+                  type="button"
+                  class="size-btn"
+                  data-size="3"
+                  aria-label="Set max dimension to 3 inches"
+                  data-tooltip="Set max dimension to 3 inches"
+                  aria-pressed="false"
+                >
+                  3"
+                </button>
+                <div class="ml-4 flex items-center">
+                  <span class="text-sm mr-2" aria-hidden="true">in</span>
+                  <label
+                    for="unitToggle"
+                    class="flex items-center cursor-pointer"
+                  >
+                    <div class="relative">
+                      <input
+                        type="checkbox"
+                        id="unitToggle"
+                        class="sr-only peer"
+                        role="switch"
+                        aria-label="Use Metric Units"
+                      />
+                      <div
+                        class="block bg-gray-600 w-14 h-8 rounded-full peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 transition-shadow"
+                      ></div>
+                      <div
+                        class="dot absolute left-1 top-1 bg-white w-6 h-6 rounded-full transition"
+                      ></div>
+                    </div>
+                  </label>
+                  <span class="text-sm ml-2" aria-hidden="true">mm</span>
                 </div>
-              </label>
-              <span class="text-sm ml-2" aria-hidden="true">mm</span>
-            </div>
-          </div>
+              </div>
             </div>
             <!-- Cutline Controls -->
-            <div class="control-group-cutline flex flex-wrap justify-center items-center gap-4" style="display: none;">
-              <div class="flex flex-col justify-center items-center w-full sm:w-auto min-w-[150px]">
+            <div
+              class="control-group-cutline flex flex-wrap justify-center items-center gap-4"
+              style="display: none"
+            >
+              <div
+                class="flex flex-col justify-center items-center w-full sm:w-auto min-w-[150px]"
+              >
                 <span class="text-xs text-gray-500 mb-1">Shape</span>
-                <select id="cutShapeSelect" class="text-xs border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-indigo-500">
+                <select
+                  id="cutShapeSelect"
+                  class="text-xs border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                >
                   <option value="trace">Trace Contour</option>
                   <option value="circle">Circle</option>
                   <option value="square">Square</option>
                 </select>
               </div>
-              <div class="flex flex-col justify-center items-center w-full sm:w-auto min-w-[150px]">
+              <div
+                class="flex flex-col justify-center items-center w-full sm:w-auto min-w-[150px]"
+              >
                 <span class="text-xs text-gray-500 mb-1">Cut Type</span>
-                <label for="cutTypeToggle" class="flex items-center cursor-pointer space-x-2">
+                <label
+                  for="cutTypeToggle"
+                  class="flex items-center cursor-pointer space-x-2"
+                >
                   <span class="text-xs font-bold text-gray-600">Edge</span>
                   <div class="relative">
-                    <input type="checkbox" id="cutTypeToggle" class="sr-only peer" role="switch" aria-label="Toggle Cut Type">
-                    <div class="block bg-gray-600 w-14 h-8 rounded-full peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 transition-shadow"></div>
-                    <div class="dot absolute left-1 top-1 bg-white w-6 h-6 rounded-full transition"></div>
+                    <input
+                      type="checkbox"
+                      id="cutTypeToggle"
+                      class="sr-only peer"
+                      role="switch"
+                      aria-label="Toggle Cut Type"
+                    />
+                    <div
+                      class="block bg-gray-600 w-14 h-8 rounded-full peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 transition-shadow"
+                    ></div>
+                    <div
+                      class="dot absolute left-1 top-1 bg-white w-6 h-6 rounded-full transition"
+                    ></div>
                   </div>
                   <span class="text-xs font-bold text-gray-600">Contour</span>
                 </label>
               </div>
-              <div class="flex flex-col justify-center items-center w-full sm:w-auto min-w-[150px]">
+              <div
+                class="flex flex-col justify-center items-center w-full sm:w-auto min-w-[150px]"
+              >
                 <label
                   for="cutlineOffsetSlider"
                   class="text-xs text-gray-500 mb-1"
@@ -540,9 +616,11 @@
                   >
                 </div>
               </div>
-              
+
               <!-- Bleed Gradient Controls -->
-              <div class="flex flex-col justify-center items-center w-full sm:w-auto min-w-[150px]">
+              <div
+                class="flex flex-col justify-center items-center w-full sm:w-auto min-w-[150px]"
+              >
                 <span class="text-xs text-gray-500 mb-1">Bleed Gradient</span>
                 <div class="flex items-center gap-2">
                   <input
@@ -561,7 +639,7 @@
                   />
                 </div>
               </div>
-              
+
               <div
                 id="cutlineSensitivityContainer"
                 style="display: none"
@@ -569,9 +647,28 @@
               >
                 <label
                   for="cutlineSensitivitySlider"
-                  class="text-xs text-gray-500 mb-1"
-                  >Edge Sensitivity</label
+                  class="text-xs text-gray-500 mb-1 flex items-center gap-1"
                 >
+                  Edge Sensitivity
+                  <svg
+                    tabindex="0"
+                    role="button"
+                    aria-label="Edge Sensitivity Help: Adjust background detection tolerance"
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke-width="1.5"
+                    stroke="currentColor"
+                    class="w-4 h-4 text-gray-400 cursor-help focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-splotch-navy rounded-full"
+                    data-tooltip="Adjust background detection tolerance"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z"
+                    />
+                  </svg>
+                </label>
                 <div class="flex items-center gap-1 w-full px-2">
                   <input
                     type="range"
@@ -581,7 +678,6 @@
                     value="42"
                     step="1"
                     class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-splotch-teal"
-                    data-tooltip="Adjust background detection tolerance"
                   />
                   <span
                     id="cutlineSensitivityValue"
@@ -595,9 +691,30 @@
                 style="display: none"
                 class="flex flex-col justify-center items-center w-full sm:w-auto min-w-[150px]"
               >
-                <label for="lazyLassoSlider" class="text-xs text-gray-500 mb-1"
-                  >Lazy Lasso</label
+                <label
+                  for="lazyLassoSlider"
+                  class="text-xs text-gray-500 mb-1 flex items-center gap-1"
                 >
+                  Lazy Lasso
+                  <svg
+                    tabindex="0"
+                    role="button"
+                    aria-label="Lazy Lasso Help: Smooths out deep cuts and gaps"
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke-width="1.5"
+                    stroke="currentColor"
+                    class="w-4 h-4 text-gray-400 cursor-help focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-splotch-navy rounded-full"
+                    data-tooltip="Smooths out deep cuts and gaps"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z"
+                    />
+                  </svg>
+                </label>
                 <div class="flex items-center gap-1 w-full px-2">
                   <input
                     type="range"
@@ -607,7 +724,6 @@
                     value="50"
                     step="1"
                     class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-splotch-teal"
-                    data-tooltip="Smooths out deep cuts and gaps"
                   />
                   <span
                     id="lazyLassoValue"
@@ -616,9 +732,20 @@
                   >
                 </div>
               </div>
-              <div class="flex items-center gap-2" id="cutTypeContainer" style="display: none;">
-                <label for="cutTypeSelect" class="text-sm font-medium text-gray-700">Cut Type:</label>
-                <select id="cutTypeSelect" class="input px-2 py-1 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+              <div
+                class="flex items-center gap-2"
+                id="cutTypeContainer"
+                style="display: none"
+              >
+                <label
+                  for="cutTypeSelect"
+                  class="text-sm font-medium text-gray-700"
+                  >Cut Type:</label
+                >
+                <select
+                  id="cutTypeSelect"
+                  class="input px-2 py-1 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                >
                   <option value="die_cut">Die Cut (Through backer)</option>
                   <option value="kiss_cut">Kiss Cut (Sticker only)</option>
                 </select>
@@ -635,27 +762,70 @@
             </div>
 
             <!-- Custom Layer Controls -->
-            <div class="control-group-custom flex flex-wrap justify-center items-center gap-4" style="display: none;">
-              <div id="customLayerTypeContainer" class="flex items-center gap-2" style="display: none;">
-                <label for="customLayerTypeSelect" class="text-sm font-medium text-gray-700">Inlay Type:</label>
-                <select id="customLayerTypeSelect" class="input px-2 py-1 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+            <div
+              class="control-group-custom flex flex-wrap justify-center items-center gap-4"
+              style="display: none"
+            >
+              <div
+                id="customLayerTypeContainer"
+                class="flex items-center gap-2"
+                style="display: none"
+              >
+                <label
+                  for="customLayerTypeSelect"
+                  class="text-sm font-medium text-gray-700"
+                  >Inlay Type:</label
+                >
+                <select
+                  id="customLayerTypeSelect"
+                  class="input px-2 py-1 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                >
                   <!-- Populated by JS -->
                 </select>
               </div>
 
               <div class="flex items-center gap-2">
-                <label for="customLayerImageUpload" class="text-sm font-medium text-gray-700">Upload Mask Image:</label>
-                <input type="file" id="customLayerImageUpload" class="input block text-sm text-gray-500 file:mr-2 file:py-1 file:px-3 file:rounded-md file:border-0 file:text-xs file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100" accept="image/*, image/svg+xml, .png,.jpeg,.jpg,.webp,.tiff,.svg,.pdf,.ai">
+                <label
+                  for="customLayerImageUpload"
+                  class="text-sm font-medium text-gray-700"
+                  >Upload Mask Image:</label
+                >
+                <input
+                  type="file"
+                  id="customLayerImageUpload"
+                  class="input block text-sm text-gray-500 file:mr-2 file:py-1 file:px-3 file:rounded-md file:border-0 file:text-xs file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100"
+                  accept="image/*, image/svg+xml, .png,.jpeg,.jpg,.webp,.tiff,.svg,.pdf,.ai"
+                />
               </div>
 
               <div class="flex items-center gap-2">
-                <label for="alphaColorPicker" class="text-sm font-medium text-gray-700" data-tooltip="The color in the uploaded image to make transparent (e.g. White background)">Alpha Color:</label>
-                <input type="color" id="alphaColorPicker" value="#ffffff" class="w-8 h-8 p-0 border-0 rounded cursor-pointer">
+                <label
+                  for="alphaColorPicker"
+                  class="text-sm font-medium text-gray-700"
+                  data-tooltip="The color in the uploaded image to make transparent (e.g. White background)"
+                  >Alpha Color:</label
+                >
+                <input
+                  type="color"
+                  id="alphaColorPicker"
+                  value="#ffffff"
+                  class="w-8 h-8 p-0 border-0 rounded cursor-pointer"
+                />
               </div>
 
               <div class="flex items-center gap-2">
-                <label for="maskColorPicker" class="text-sm font-medium text-gray-700" data-tooltip="The color in the uploaded image to convert to the mask (e.g. Red square)">Mask Color:</label>
-                <input type="color" id="maskColorPicker" value="#000000" class="w-8 h-8 p-0 border-0 rounded cursor-pointer">
+                <label
+                  for="maskColorPicker"
+                  class="text-sm font-medium text-gray-700"
+                  data-tooltip="The color in the uploaded image to convert to the mask (e.g. Red square)"
+                  >Mask Color:</label
+                >
+                <input
+                  type="color"
+                  id="maskColorPicker"
+                  value="#000000"
+                  class="w-8 h-8 p-0 border-0 rounded cursor-pointer"
+                />
               </div>
 
               <button
@@ -814,7 +984,6 @@
             </div>
           </div>
 
-
           <!-- Sticker Options -->
           <div class="space-y-4">
             <h3
@@ -858,19 +1027,45 @@
                   </button>
                 </div>
                 <!-- DISCOUNT TABLE HERE -->
-                <div id="discountTableContainer" class="mt-3 text-xs text-gray-600 hidden">
-                  <p class="font-semibold text-indigo-700 mb-1 flex items-center gap-1">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z" />
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M6 6h.008v.008H6V6Z" />
+                <div
+                  id="discountTableContainer"
+                  class="mt-3 text-xs text-gray-600 hidden"
+                >
+                  <p
+                    class="font-semibold text-indigo-700 mb-1 flex items-center gap-1"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke-width="1.5"
+                      stroke="currentColor"
+                      class="size-4"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z"
+                      />
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M6 6h.008v.008H6V6Z"
+                      />
                     </svg>
                     Bulk Discounts Applied Automatically!
                   </p>
-                  <table class="w-full border-collapse border border-gray-200 text-left rounded-md overflow-hidden shadow-sm">
-                    <thead class="bg-indigo-50 text-indigo-900 border-b border-gray-200">
+                  <table
+                    class="w-full border-collapse border border-gray-200 text-left rounded-md overflow-hidden shadow-sm"
+                  >
+                    <thead
+                      class="bg-indigo-50 text-indigo-900 border-b border-gray-200"
+                    >
                       <tr>
                         <th class="px-2 py-1 font-medium">Quantity</th>
-                        <th class="px-2 py-1 font-medium text-right">Discount</th>
+                        <th class="px-2 py-1 font-medium text-right">
+                          Discount
+                        </th>
                       </tr>
                     </thead>
                     <tbody id="discountTableBody" class="bg-white">
@@ -893,8 +1088,12 @@
                     aria-describedby="material-helper"
                   >
                     <option value="pp_standard">Gloss White Air Release</option>
-                    <option value="pvc_laminated">Extra Durable PVC + Lamination</option>
-                    <option value="finish_holographic">Holographic (Iridescent)</option>
+                    <option value="pvc_laminated">
+                      Extra Durable PVC + Lamination
+                    </option>
+                    <option value="finish_holographic">
+                      Holographic (Iridescent)
+                    </option>
                     <option value="finish_glitter">Glitter (Sparkle)</option>
                     <option value="finish_matte">Matte Soft-Touch</option>
                   </select>
@@ -960,17 +1159,31 @@
               </p>
             </div>
 
-
-
-            <div class="field bg-indigo-50 rounded-md border border-indigo-100 p-4 mt-4">
+            <div
+              class="field bg-indigo-50 rounded-md border border-indigo-100 p-4 mt-4"
+            >
               <label class="flex items-start gap-3 cursor-pointer">
                 <div class="flex items-center h-5">
-                  <input id="promoAddonCheckbox" name="promoAddonCheckbox" type="checkbox" class="w-4 h-4 text-indigo-600 bg-white border-gray-300 rounded focus:ring-indigo-500">
+                  <input
+                    id="promoAddonCheckbox"
+                    name="promoAddonCheckbox"
+                    type="checkbox"
+                    class="w-4 h-4 text-indigo-600 bg-white border-gray-300 rounded focus:ring-indigo-500"
+                  />
                 </div>
                 <div class="text-sm">
-                  <span class="font-medium text-indigo-900">Add Holographic Promo Sticker</span>
-                  <p class="text-indigo-700 mt-1">Get an exclusive holographic logo sticker for $2.00!</p>
-                  <p class="text-indigo-700 font-bold mt-1 text-xs uppercase tracking-wide" id="promoAddonStatusMsg">Free on orders of 50 or more items!</p>
+                  <span class="font-medium text-indigo-900"
+                    >Add Holographic Promo Sticker</span
+                  >
+                  <p class="text-indigo-700 mt-1">
+                    Get an exclusive holographic logo sticker for $2.00!
+                  </p>
+                  <p
+                    class="text-indigo-700 font-bold mt-1 text-xs uppercase tracking-wide"
+                    id="promoAddonStatusMsg"
+                  >
+                    Free on orders of 50 or more items!
+                  </p>
                 </div>
               </label>
             </div>
@@ -1010,7 +1223,10 @@
 
         <!-- Payment Form -->
         <div class="space-y-6 bg-gray-50 p-6 rounded-lg shadow-md">
-          <h2 class="text-3xl font-semibold text-splotch-navy pb-2" style="font-family: var(--font-modak)">
+          <h2
+            class="text-3xl font-semibold text-splotch-navy pb-2"
+            style="font-family: var(--font-modak)"
+          >
             Order Your Custom Stickers & Pay
           </h2>
           <h3 class="text-lg font-semibold text-gray-700 mt-6 pt-4 border-t">
@@ -1318,7 +1534,11 @@
         <a href="/terms.html" class="text-splotch-red hover:underline"
           >Terms & FAQ</a
         >
-       | <span class="text-xs text-gray-400 ml-2">v<span class="app-version-display"></span></span></div>
+        |
+        <span class="text-xs text-gray-400 ml-2"
+          >v<span class="app-version-display"></span
+        ></span>
+      </div>
     </footer>
 
     <div
@@ -1336,5 +1556,5 @@
     </div>
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>
     <script type="module" src="./src/version.js"></script>
-</body>
+  </body>
 </html>

--- a/output.css
+++ b/output.css
@@ -7,13 +7,21 @@
       "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
     --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
       "Courier New", monospace;
+    --color-red-100: oklch(93.6% 0.032 17.717);
+    --color-red-200: oklch(88.5% 0.062 18.334);
     --color-red-500: oklch(63.7% 0.237 25.331);
     --color-red-600: oklch(57.7% 0.245 27.325);
+    --color-red-700: oklch(50.5% 0.213 27.518);
+    --color-red-800: oklch(44.4% 0.177 26.899);
+    --color-amber-700: oklch(55.5% 0.163 48.998);
     --color-yellow-500: oklch(79.5% 0.184 86.047);
+    --color-green-100: oklch(96.2% 0.044 156.743);
     --color-green-500: oklch(72.3% 0.219 149.579);
     --color-green-600: oklch(62.7% 0.194 149.214);
     --color-green-700: oklch(52.7% 0.154 150.069);
+    --color-emerald-700: oklch(50.8% 0.118 165.612);
     --color-teal-500: oklch(70.4% 0.14 182.503);
+    --color-blue-50: oklch(97% 0.014 254.604);
     --color-blue-100: oklch(93.2% 0.032 255.585);
     --color-blue-300: oklch(80.9% 0.105 251.813);
     --color-blue-500: oklch(62.3% 0.214 259.815);
@@ -22,10 +30,17 @@
     --color-blue-800: oklch(42.4% 0.199 265.638);
     --color-indigo-50: oklch(96.2% 0.018 272.314);
     --color-indigo-100: oklch(93% 0.034 272.788);
+    --color-indigo-200: oklch(87% 0.065 274.039);
     --color-indigo-500: oklch(58.5% 0.233 277.117);
+    --color-indigo-600: oklch(51.1% 0.262 276.966);
     --color-indigo-700: oklch(45.7% 0.24 277.023);
+    --color-indigo-900: oklch(35.9% 0.144 278.697);
+    --color-violet-600: oklch(54.1% 0.281 293.009);
+    --color-purple-100: oklch(94.6% 0.033 307.174);
     --color-purple-500: oklch(62.7% 0.265 303.9);
     --color-purple-600: oklch(55.8% 0.288 302.321);
+    --color-purple-700: oklch(49.6% 0.265 301.924);
+    --color-purple-900: oklch(38.1% 0.176 304.987);
     --color-slate-50: oklch(98.4% 0.003 247.858);
     --color-slate-100: oklch(96.8% 0.007 247.896);
     --color-slate-200: oklch(92.9% 0.013 255.508);
@@ -43,8 +58,10 @@
     --color-black: #000;
     --color-white: #fff;
     --spacing: 0.25rem;
+    --container-xs: 20rem;
     --container-sm: 24rem;
     --container-md: 28rem;
+    --container-4xl: 56rem;
     --text-xs: 0.75rem;
     --text-xs--line-height: calc(1 / 0.75);
     --text-sm: 0.875rem;
@@ -57,14 +74,20 @@
     --text-2xl--line-height: calc(2 / 1.5);
     --text-3xl: 1.875rem;
     --text-3xl--line-height: calc(2.25 / 1.875);
+    --font-weight-normal: 400;
     --font-weight-medium: 500;
     --font-weight-semibold: 600;
     --font-weight-bold: 700;
+    --tracking-wide: 0.025em;
+    --tracking-wider: 0.05em;
     --leading-tight: 1.25;
     --radius-md: 0.375rem;
     --radius-lg: 0.5rem;
+    --ease-in: cubic-bezier(0.4, 0, 1, 1);
+    --ease-out: cubic-bezier(0, 0, 0.2, 1);
     --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
     --animate-spin: spin 1s linear infinite;
+    --animate-pulse: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
     --blur-sm: 8px;
     --default-transition-duration: 150ms;
     --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
@@ -221,6 +244,15 @@
   }
 }
 @layer utilities {
+  .pointer-events-auto {
+    pointer-events: auto;
+  }
+  .pointer-events-none {
+    pointer-events: none;
+  }
+  .collapse {
+    visibility: collapse;
+  }
   .visible {
     visibility: visible;
   }
@@ -256,17 +288,17 @@
   .top-1 {
     top: calc(var(--spacing) * 1);
   }
+  .top-24 {
+    top: calc(var(--spacing) * 24);
+  }
   .right-0 {
     right: calc(var(--spacing) * 0);
   }
-  .right-2 {
-    right: calc(var(--spacing) * 2);
+  .right-4 {
+    right: calc(var(--spacing) * 4);
   }
   .bottom-0 {
     bottom: calc(var(--spacing) * 0);
-  }
-  .bottom-2 {
-    bottom: calc(var(--spacing) * 2);
   }
   .left-0 {
     left: calc(var(--spacing) * 0);
@@ -274,11 +306,23 @@
   .left-1 {
     left: calc(var(--spacing) * 1);
   }
+  .isolate {
+    isolation: isolate;
+  }
+  .z-10 {
+    z-index: 10;
+  }
   .z-20 {
     z-index: 20;
   }
   .z-50 {
     z-index: 50;
+  }
+  .z-\[100\] {
+    z-index: 100;
+  }
+  .z-\[10000\] {
+    z-index: 10000;
   }
   .order-1 {
     order: 1;
@@ -286,8 +330,8 @@
   .order-2 {
     order: 2;
   }
-  .col-span-2 {
-    grid-column: span 2 / span 2;
+  .order-123 {
+    order: 123;
   }
   .container {
     width: 100%;
@@ -307,17 +351,20 @@
       max-width: 96rem;
     }
   }
+  .-mx-1\.5 {
+    margin-inline: calc(var(--spacing) * -1.5);
+  }
   .mx-4 {
     margin-inline: calc(var(--spacing) * 4);
   }
   .mx-auto {
     margin-inline: auto;
   }
+  .-my-1\.5 {
+    margin-block: calc(var(--spacing) * -1.5);
+  }
   .my-2 {
     margin-block: calc(var(--spacing) * 2);
-  }
-  .my-4 {
-    margin-block: calc(var(--spacing) * 4);
   }
   .my-6 {
     margin-block: calc(var(--spacing) * 6);
@@ -331,6 +378,9 @@
   .mt-2 {
     margin-top: calc(var(--spacing) * 2);
   }
+  .mt-3 {
+    margin-top: calc(var(--spacing) * 3);
+  }
   .mt-4 {
     margin-top: calc(var(--spacing) * 4);
   }
@@ -343,8 +393,14 @@
   .mr-2 {
     margin-right: calc(var(--spacing) * 2);
   }
+  .mr-3 {
+    margin-right: calc(var(--spacing) * 3);
+  }
   .mr-4 {
     margin-right: calc(var(--spacing) * 4);
+  }
+  .mb-0 {
+    margin-bottom: calc(var(--spacing) * 0);
   }
   .mb-1 {
     margin-bottom: calc(var(--spacing) * 1);
@@ -370,8 +426,14 @@
   .ml-2 {
     margin-left: calc(var(--spacing) * 2);
   }
+  .ml-3 {
+    margin-left: calc(var(--spacing) * 3);
+  }
   .ml-4 {
     margin-left: calc(var(--spacing) * 4);
+  }
+  .ml-auto {
+    margin-left: auto;
   }
   .block {
     display: block;
@@ -388,6 +450,9 @@
   .hidden {
     display: none;
   }
+  .inline {
+    display: inline;
+  }
   .inline-block {
     display: inline-block;
   }
@@ -396,6 +461,16 @@
   }
   .table {
     display: table;
+  }
+  .size-4 {
+    width: calc(var(--spacing) * 4);
+    height: calc(var(--spacing) * 4);
+  }
+  .h-0 {
+    height: calc(var(--spacing) * 0);
+  }
+  .h-2 {
+    height: calc(var(--spacing) * 2);
   }
   .h-3 {
     height: calc(var(--spacing) * 3);
@@ -429,6 +504,9 @@
   }
   .min-h-\[50px\] {
     min-height: 50px;
+  }
+  .w-0 {
+    width: calc(var(--spacing) * 0);
   }
   .w-3 {
     width: calc(var(--spacing) * 3);
@@ -466,11 +544,29 @@
   .w-full {
     width: 100%;
   }
+  .max-w-4xl {
+    max-width: var(--container-4xl);
+  }
   .max-w-md {
     max-width: var(--container-md);
   }
   .max-w-sm {
     max-width: var(--container-sm);
+  }
+  .max-w-xs {
+    max-width: var(--container-xs);
+  }
+  .min-w-0 {
+    min-width: calc(var(--spacing) * 0);
+  }
+  .min-w-\[80px\] {
+    min-width: 80px;
+  }
+  .min-w-\[150px\] {
+    min-width: 150px;
+  }
+  .min-w-full {
+    min-width: 100%;
   }
   .flex-shrink-0 {
     flex-shrink: 0;
@@ -478,11 +574,37 @@
   .flex-grow {
     flex-grow: 1;
   }
+  .grow {
+    flex-grow: 1;
+  }
   .border-collapse {
     border-collapse: collapse;
   }
+  .translate-x-full {
+    --tw-translate-x: 100%;
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
+  .translate-y-full {
+    --tw-translate-y: 100%;
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
+  .scale-100 {
+    --tw-scale-x: 100%;
+    --tw-scale-y: 100%;
+    --tw-scale-z: 100%;
+    scale: var(--tw-scale-x) var(--tw-scale-y);
+  }
+  .scale-105 {
+    --tw-scale-x: 105%;
+    --tw-scale-y: 105%;
+    --tw-scale-z: 105%;
+    scale: var(--tw-scale-x) var(--tw-scale-y);
+  }
   .transform {
     transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
+  }
+  .animate-pulse {
+    animation: var(--animate-pulse);
   }
   .animate-spin {
     animation: var(--animate-spin);
@@ -495,6 +617,9 @@
   }
   .resize {
     resize: both;
+  }
+  .scroll-mt-32 {
+    scroll-margin-top: calc(var(--spacing) * 32);
   }
   .appearance-none {
     appearance: none;
@@ -511,6 +636,9 @@
   .flex-wrap {
     flex-wrap: wrap;
   }
+  .items-baseline {
+    align-items: baseline;
+  }
   .items-center {
     align-items: center;
   }
@@ -526,6 +654,12 @@
   .justify-center {
     justify-content: center;
   }
+  .justify-end {
+    justify-content: flex-end;
+  }
+  .gap-1 {
+    gap: calc(var(--spacing) * 1);
+  }
   .gap-2 {
     gap: calc(var(--spacing) * 2);
   }
@@ -540,6 +674,13 @@
   }
   .gap-8 {
     gap: calc(var(--spacing) * 8);
+  }
+  .space-y-3 {
+    :where(& > :not(:last-child)) {
+      --tw-space-y-reverse: 0;
+      margin-block-start: calc(calc(var(--spacing) * 3) * var(--tw-space-y-reverse));
+      margin-block-end: calc(calc(var(--spacing) * 3) * calc(1 - var(--tw-space-y-reverse)));
+    }
   }
   .space-y-4 {
     :where(& > :not(:last-child)) {
@@ -576,6 +717,16 @@
       margin-inline-end: calc(calc(var(--spacing) * 2) * calc(1 - var(--tw-space-x-reverse)));
     }
   }
+  .space-x-4 {
+    :where(& > :not(:last-child)) {
+      --tw-space-x-reverse: 0;
+      margin-inline-start: calc(calc(var(--spacing) * 4) * var(--tw-space-x-reverse));
+      margin-inline-end: calc(calc(var(--spacing) * 4) * calc(1 - var(--tw-space-x-reverse)));
+    }
+  }
+  .self-center {
+    align-self: center;
+  }
   .self-end {
     align-self: flex-end;
   }
@@ -586,6 +737,12 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+  .overflow-hidden {
+    overflow: hidden;
+  }
+  .overflow-x-auto {
+    overflow-x: auto;
   }
   .rounded {
     border-radius: 0.25rem;
@@ -599,9 +756,29 @@
   .rounded-md {
     border-radius: var(--radius-md);
   }
+  .rounded-t-lg {
+    border-top-left-radius: var(--radius-lg);
+    border-top-right-radius: var(--radius-lg);
+  }
+  .rounded-t-md {
+    border-top-left-radius: var(--radius-md);
+    border-top-right-radius: var(--radius-md);
+  }
+  .rounded-l-md {
+    border-top-left-radius: var(--radius-md);
+    border-bottom-left-radius: var(--radius-md);
+  }
+  .rounded-r-md {
+    border-top-right-radius: var(--radius-md);
+    border-bottom-right-radius: var(--radius-md);
+  }
   .border {
     border-style: var(--tw-border-style);
     border-width: 1px;
+  }
+  .border-0 {
+    border-style: var(--tw-border-style);
+    border-width: 0px;
   }
   .border-2 {
     border-style: var(--tw-border-style);
@@ -615,13 +792,33 @@
     border-top-style: var(--tw-border-style);
     border-top-width: 2px;
   }
+  .border-t-4 {
+    border-top-style: var(--tw-border-style);
+    border-top-width: 4px;
+  }
+  .border-r-0 {
+    border-right-style: var(--tw-border-style);
+    border-right-width: 0px;
+  }
   .border-b {
     border-bottom-style: var(--tw-border-style);
     border-bottom-width: 1px;
   }
+  .border-b-0 {
+    border-bottom-style: var(--tw-border-style);
+    border-bottom-width: 0px;
+  }
   .border-b-2 {
     border-bottom-style: var(--tw-border-style);
     border-bottom-width: 2px;
+  }
+  .border-l {
+    border-left-style: var(--tw-border-style);
+    border-left-width: 1px;
+  }
+  .border-l-0 {
+    border-left-style: var(--tw-border-style);
+    border-left-width: 0px;
   }
   .border-l-4 {
     border-left-style: var(--tw-border-style);
@@ -631,8 +828,18 @@
     --tw-border-style: dashed;
     border-style: dashed;
   }
+  .border-solid {
+    --tw-border-style: solid;
+    border-style: solid;
+  }
+  .border-blue-100 {
+    border-color: var(--color-blue-100);
+  }
   .border-blue-500 {
     border-color: var(--color-blue-500);
+  }
+  .border-gray-100 {
+    border-color: var(--color-gray-100);
   }
   .border-gray-200 {
     border-color: var(--color-gray-200);
@@ -640,14 +847,44 @@
   .border-gray-300 {
     border-color: var(--color-gray-300);
   }
+  .border-green-500 {
+    border-color: var(--color-green-500);
+  }
+  .border-indigo-100 {
+    border-color: var(--color-indigo-100);
+  }
+  .border-indigo-200 {
+    border-color: var(--color-indigo-200);
+  }
+  .border-purple-500 {
+    border-color: var(--color-purple-500);
+  }
+  .border-red-200 {
+    border-color: var(--color-red-200);
+  }
+  .border-splotch-navy {
+    border-color: #2A284D;
+  }
   .border-splotch-red {
     border-color: #FF003A;
+  }
+  .border-splotch-teal {
+    border-color: #00A99D;
   }
   .border-transparent {
     border-color: transparent;
   }
+  .border-yellow-500 {
+    border-color: var(--color-yellow-500);
+  }
+  .bg-amber-700 {
+    background-color: var(--color-amber-700);
+  }
   .bg-black {
     background-color: var(--color-black);
+  }
+  .bg-blue-50 {
+    background-color: var(--color-blue-50);
   }
   .bg-blue-100 {
     background-color: var(--color-blue-100);
@@ -655,11 +892,20 @@
   .bg-blue-500 {
     background-color: var(--color-blue-500);
   }
+  .bg-blue-600 {
+    background-color: var(--color-blue-600);
+  }
+  .bg-emerald-700 {
+    background-color: var(--color-emerald-700);
+  }
   .bg-gray-50 {
     background-color: var(--color-gray-50);
   }
   .bg-gray-100 {
     background-color: var(--color-gray-100);
+  }
+  .bg-gray-200 {
+    background-color: var(--color-gray-200);
   }
   .bg-gray-300 {
     background-color: var(--color-gray-300);
@@ -676,32 +922,59 @@
   .bg-gray-900 {
     background-color: var(--color-gray-900);
   }
+  .bg-green-100 {
+    background-color: var(--color-green-100);
+  }
   .bg-green-500 {
     background-color: var(--color-green-500);
   }
   .bg-green-600 {
     background-color: var(--color-green-600);
   }
+  .bg-green-700 {
+    background-color: var(--color-green-700);
+  }
+  .bg-indigo-50 {
+    background-color: var(--color-indigo-50);
+  }
+  .bg-indigo-100 {
+    background-color: var(--color-indigo-100);
+  }
+  .bg-indigo-600 {
+    background-color: var(--color-indigo-600);
+  }
+  .bg-purple-100 {
+    background-color: var(--color-purple-100);
+  }
   .bg-purple-500 {
     background-color: var(--color-purple-500);
+  }
+  .bg-red-100 {
+    background-color: var(--color-red-100);
   }
   .bg-red-500 {
     background-color: var(--color-red-500);
   }
+  .bg-red-600 {
+    background-color: var(--color-red-600);
+  }
   .bg-slate-50 {
     background-color: var(--color-slate-50);
   }
-  .bg-slate-100 {
-    background-color: var(--color-slate-100);
-  }
   .bg-slate-200 {
     background-color: var(--color-slate-200);
+  }
+  .bg-splotch-navy {
+    background-color: #2A284D;
   }
   .bg-splotch-red {
     background-color: #FF003A;
   }
   .bg-teal-500 {
     background-color: var(--color-teal-500);
+  }
+  .bg-violet-600 {
+    background-color: var(--color-violet-600);
   }
   .bg-white {
     background-color: var(--color-white);
@@ -718,8 +991,14 @@
   .object-cover {
     object-fit: cover;
   }
+  .p-0 {
+    padding: calc(var(--spacing) * 0);
+  }
   .p-1 {
     padding: calc(var(--spacing) * 1);
+  }
+  .p-1\.5 {
+    padding: calc(var(--spacing) * 1.5);
   }
   .p-2 {
     padding: calc(var(--spacing) * 2);
@@ -736,6 +1015,12 @@
   .p-8 {
     padding: calc(var(--spacing) * 8);
   }
+  .px-1 {
+    padding-inline: calc(var(--spacing) * 1);
+  }
+  .px-2 {
+    padding-inline: calc(var(--spacing) * 2);
+  }
   .px-3 {
     padding-inline: calc(var(--spacing) * 3);
   }
@@ -745,8 +1030,14 @@
   .px-6 {
     padding-inline: calc(var(--spacing) * 6);
   }
+  .py-0\.5 {
+    padding-block: calc(var(--spacing) * 0.5);
+  }
   .py-1 {
     padding-block: calc(var(--spacing) * 1);
+  }
+  .py-1\.5 {
+    padding-block: calc(var(--spacing) * 1.5);
   }
   .py-2 {
     padding-block: calc(var(--spacing) * 2);
@@ -769,11 +1060,26 @@
   .pt-4 {
     padding-top: calc(var(--spacing) * 4);
   }
+  .pt-28 {
+    padding-top: calc(var(--spacing) * 28);
+  }
   .pb-2 {
     padding-bottom: calc(var(--spacing) * 2);
   }
+  .pb-4 {
+    padding-bottom: calc(var(--spacing) * 4);
+  }
+  .pl-4 {
+    padding-left: calc(var(--spacing) * 4);
+  }
   .text-center {
     text-align: center;
+  }
+  .text-left {
+    text-align: left;
+  }
+  .text-right {
+    text-align: right;
   }
   .font-mono {
     font-family: var(--font-mono);
@@ -814,12 +1120,36 @@
     --tw-font-weight: var(--font-weight-medium);
     font-weight: var(--font-weight-medium);
   }
+  .font-normal {
+    --tw-font-weight: var(--font-weight-normal);
+    font-weight: var(--font-weight-normal);
+  }
   .font-semibold {
     --tw-font-weight: var(--font-weight-semibold);
     font-weight: var(--font-weight-semibold);
   }
+  .tracking-wide {
+    --tw-tracking: var(--tracking-wide);
+    letter-spacing: var(--tracking-wide);
+  }
+  .tracking-wider {
+    --tw-tracking: var(--tracking-wider);
+    letter-spacing: var(--tracking-wider);
+  }
+  .whitespace-nowrap {
+    white-space: nowrap;
+  }
+  .text-blue-500 {
+    color: var(--color-blue-500);
+  }
   .text-blue-600 {
     color: var(--color-blue-600);
+  }
+  .text-blue-800 {
+    color: var(--color-blue-800);
+  }
+  .text-current {
+    color: currentcolor;
   }
   .text-gray-400 {
     color: var(--color-gray-400);
@@ -839,11 +1169,29 @@
   .text-gray-900 {
     color: var(--color-gray-900);
   }
+  .text-green-500 {
+    color: var(--color-green-500);
+  }
   .text-green-600 {
     color: var(--color-green-600);
   }
+  .text-indigo-600 {
+    color: var(--color-indigo-600);
+  }
+  .text-indigo-700 {
+    color: var(--color-indigo-700);
+  }
+  .text-indigo-900 {
+    color: var(--color-indigo-900);
+  }
+  .text-purple-700 {
+    color: var(--color-purple-700);
+  }
   .text-red-500 {
     color: var(--color-red-500);
+  }
+  .text-red-600 {
+    color: var(--color-red-600);
   }
   .text-slate-800 {
     color: var(--color-slate-800);
@@ -860,11 +1208,20 @@
   .text-white {
     color: var(--color-white);
   }
-  .italic {
-    font-style: italic;
+  .lowercase {
+    text-transform: lowercase;
+  }
+  .uppercase {
+    text-transform: uppercase;
   }
   .underline {
     text-decoration-line: underline;
+  }
+  .accent-splotch-teal {
+    accent-color: #00A99D;
+  }
+  .opacity-0 {
+    opacity: 0%;
   }
   .opacity-25 {
     opacity: 25%;
@@ -897,6 +1254,10 @@
   }
   .shadow-xl {
     --tw-shadow: 0 20px 25px -5px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 8px 10px -6px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .ring {
+    --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
   .outline {
@@ -938,6 +1299,11 @@
     transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
     transition-duration: var(--tw-duration, var(--default-transition-duration));
   }
+  .transition-opacity {
+    transition-property: opacity;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
   .transition-shadow {
     transition-property: box-shadow;
     transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
@@ -947,9 +1313,29 @@
     --tw-duration: 150ms;
     transition-duration: 150ms;
   }
+  .duration-200 {
+    --tw-duration: 200ms;
+    transition-duration: 200ms;
+  }
+  .duration-300 {
+    --tw-duration: 300ms;
+    transition-duration: 300ms;
+  }
+  .ease-in {
+    --tw-ease: var(--ease-in);
+    transition-timing-function: var(--ease-in);
+  }
   .ease-in-out {
     --tw-ease: var(--ease-in-out);
     transition-timing-function: var(--ease-in-out);
+  }
+  .ease-out {
+    --tw-ease: var(--ease-out);
+    transition-timing-function: var(--ease-out);
+  }
+  .outline-none {
+    --tw-outline-style: none;
+    outline-style: none;
   }
   .select-none {
     -webkit-user-select: none;
@@ -966,6 +1352,11 @@
       --tw-ring-color: var(--color-blue-300);
     }
   }
+  .file\:mr-2 {
+    &::file-selector-button {
+      margin-right: calc(var(--spacing) * 2);
+    }
+  }
   .file\:mr-4 {
     &::file-selector-button {
       margin-right: calc(var(--spacing) * 4);
@@ -974,6 +1365,11 @@
   .file\:rounded-full {
     &::file-selector-button {
       border-radius: calc(infinity * 1px);
+    }
+  }
+  .file\:rounded-md {
+    &::file-selector-button {
+      border-radius: var(--radius-md);
     }
   }
   .file\:border-0 {
@@ -987,9 +1383,19 @@
       background-color: var(--color-indigo-50);
     }
   }
+  .file\:px-3 {
+    &::file-selector-button {
+      padding-inline: calc(var(--spacing) * 3);
+    }
+  }
   .file\:px-4 {
     &::file-selector-button {
       padding-inline: calc(var(--spacing) * 4);
+    }
+  }
+  .file\:py-1 {
+    &::file-selector-button {
+      padding-block: calc(var(--spacing) * 1);
     }
   }
   .file\:py-2 {
@@ -1001,6 +1407,12 @@
     &::file-selector-button {
       font-size: var(--text-sm);
       line-height: var(--tw-leading, var(--text-sm--line-height));
+    }
+  }
+  .file\:text-xs {
+    &::file-selector-button {
+      font-size: var(--text-xs);
+      line-height: var(--tw-leading, var(--text-xs--line-height));
     }
   }
   .file\:font-semibold {
@@ -1038,6 +1450,27 @@
       }
     }
   }
+  .hover\:bg-gray-100 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-gray-100);
+      }
+    }
+  }
+  .hover\:bg-gray-200 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-gray-200);
+      }
+    }
+  }
+  .hover\:bg-gray-300 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-gray-300);
+      }
+    }
+  }
   .hover\:bg-gray-400 {
     &:hover {
       @media (hover: hover) {
@@ -1066,6 +1499,20 @@
       }
     }
   }
+  .hover\:bg-indigo-200 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-indigo-200);
+      }
+    }
+  }
+  .hover\:bg-indigo-700 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-indigo-700);
+      }
+    }
+  }
   .hover\:bg-purple-600 {
     &:hover {
       @media (hover: hover) {
@@ -1080,6 +1527,13 @@
       }
     }
   }
+  .hover\:bg-red-700 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-red-700);
+      }
+    }
+  }
   .hover\:bg-white\/80 {
     &:hover {
       @media (hover: hover) {
@@ -1090,10 +1544,80 @@
       }
     }
   }
+  .hover\:text-gray-600 {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-gray-600);
+      }
+    }
+  }
+  .hover\:text-gray-700 {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-gray-700);
+      }
+    }
+  }
   .hover\:text-gray-800 {
     &:hover {
       @media (hover: hover) {
         color: var(--color-gray-800);
+      }
+    }
+  }
+  .hover\:text-gray-900 {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-gray-900);
+      }
+    }
+  }
+  .hover\:text-green-100 {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-green-100);
+      }
+    }
+  }
+  .hover\:text-purple-900 {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-purple-900);
+      }
+    }
+  }
+  .hover\:text-red-100 {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-red-100);
+      }
+    }
+  }
+  .hover\:text-red-500 {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-red-500);
+      }
+    }
+  }
+  .hover\:text-red-700 {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-red-700);
+      }
+    }
+  }
+  .hover\:text-red-800 {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-red-800);
+      }
+    }
+  }
+  .hover\:text-splotch-teal {
+    &:hover {
+      @media (hover: hover) {
+        color: #00A99D;
       }
     }
   }
@@ -1126,10 +1650,26 @@
       border-color: var(--color-indigo-500);
     }
   }
+  .focus\:underline {
+    &:focus {
+      text-decoration-line: underline;
+    }
+  }
+  .focus\:ring-1 {
+    &:focus {
+      --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
+      box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    }
+  }
   .focus\:ring-2 {
     &:focus {
       --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
       box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    }
+  }
+  .focus\:ring-blue-500 {
+    &:focus {
+      --tw-ring-color: var(--color-blue-500);
     }
   }
   .focus\:ring-green-500 {
@@ -1159,19 +1699,138 @@
       outline-style: none;
     }
   }
+  .focus-visible\:border-transparent {
+    &:focus-visible {
+      border-color: transparent;
+    }
+  }
+  .focus-visible\:ring-2 {
+    &:focus-visible {
+      --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
+      box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    }
+  }
+  .focus-visible\:ring-4 {
+    &:focus-visible {
+      --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(4px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
+      box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    }
+  }
+  .focus-visible\:ring-amber-700 {
+    &:focus-visible {
+      --tw-ring-color: var(--color-amber-700);
+    }
+  }
+  .focus-visible\:ring-blue-500 {
+    &:focus-visible {
+      --tw-ring-color: var(--color-blue-500);
+    }
+  }
+  .focus-visible\:ring-blue-600 {
+    &:focus-visible {
+      --tw-ring-color: var(--color-blue-600);
+    }
+  }
+  .focus-visible\:ring-emerald-700 {
+    &:focus-visible {
+      --tw-ring-color: var(--color-emerald-700);
+    }
+  }
+  .focus-visible\:ring-gray-400 {
+    &:focus-visible {
+      --tw-ring-color: var(--color-gray-400);
+    }
+  }
+  .focus-visible\:ring-gray-500 {
+    &:focus-visible {
+      --tw-ring-color: var(--color-gray-500);
+    }
+  }
+  .focus-visible\:ring-gray-700 {
+    &:focus-visible {
+      --tw-ring-color: var(--color-gray-700);
+    }
+  }
+  .focus-visible\:ring-green-600 {
+    &:focus-visible {
+      --tw-ring-color: var(--color-green-600);
+    }
+  }
+  .focus-visible\:ring-green-700 {
+    &:focus-visible {
+      --tw-ring-color: var(--color-green-700);
+    }
+  }
+  .focus-visible\:ring-indigo-600 {
+    &:focus-visible {
+      --tw-ring-color: var(--color-indigo-600);
+    }
+  }
+  .focus-visible\:ring-purple-500 {
+    &:focus-visible {
+      --tw-ring-color: var(--color-purple-500);
+    }
+  }
+  .focus-visible\:ring-red-600 {
+    &:focus-visible {
+      --tw-ring-color: var(--color-red-600);
+    }
+  }
+  .focus-visible\:ring-splotch-navy {
+    &:focus-visible {
+      --tw-ring-color: #2A284D;
+    }
+  }
+  .focus-visible\:ring-splotch-red {
+    &:focus-visible {
+      --tw-ring-color: #FF003A;
+    }
+  }
+  .focus-visible\:ring-splotch-teal {
+    &:focus-visible {
+      --tw-ring-color: #00A99D;
+    }
+  }
+  .focus-visible\:ring-teal-500 {
+    &:focus-visible {
+      --tw-ring-color: var(--color-teal-500);
+    }
+  }
+  .focus-visible\:ring-violet-600 {
+    &:focus-visible {
+      --tw-ring-color: var(--color-violet-600);
+    }
+  }
+  .focus-visible\:ring-offset-2 {
+    &:focus-visible {
+      --tw-ring-offset-width: 2px;
+      --tw-ring-offset-shadow: var(--tw-ring-inset,) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+    }
+  }
+  .focus-visible\:outline-none {
+    &:focus-visible {
+      --tw-outline-style: none;
+      outline-style: none;
+    }
+  }
+  .focus-visible\:ring-inset {
+    &:focus-visible {
+      --tw-ring-inset: inset;
+    }
+  }
   .disabled\:cursor-not-allowed {
     &:disabled {
       cursor: not-allowed;
     }
   }
+  .disabled\:opacity-50 {
+    &:disabled {
+      opacity: 50%;
+    }
+  }
   .disabled\:opacity-75 {
     &:disabled {
       opacity: 75%;
-    }
-  }
-  .sm\:col-span-3 {
-    @media (width >= 40rem) {
-      grid-column: span 3 / span 3;
     }
   }
   .sm\:mx-0 {
@@ -1189,9 +1848,9 @@
       margin-left: calc(var(--spacing) * 4);
     }
   }
-  .sm\:grid-cols-3 {
+  .sm\:w-auto {
     @media (width >= 40rem) {
-      grid-template-columns: repeat(3, minmax(0, 1fr));
+      width: auto;
     }
   }
   .sm\:flex-row {
@@ -1224,11 +1883,6 @@
   .md\:col-span-2 {
     @media (width >= 48rem) {
       grid-column: span 2 / span 2;
-    }
-  }
-  .md\:col-span-4 {
-    @media (width >= 48rem) {
-      grid-column: span 4 / span 4;
     }
   }
   .md\:my-0 {
@@ -1286,9 +1940,9 @@
       grid-template-columns: repeat(4, minmax(0, 1fr));
     }
   }
-  .lg\:grid-cols-10 {
+  .lg\:flex-row {
     @media (width >= 64rem) {
-      grid-template-columns: repeat(10, minmax(0, 1fr));
+      flex-direction: row;
     }
   }
   .lg\:p-8 {
@@ -1308,6 +1962,36 @@
       }
     }
   }
+}
+@property --tw-translate-x {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+@property --tw-translate-y {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+@property --tw-translate-z {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+@property --tw-scale-x {
+  syntax: "*";
+  inherits: false;
+  initial-value: 1;
+}
+@property --tw-scale-y {
+  syntax: "*";
+  inherits: false;
+  initial-value: 1;
+}
+@property --tw-scale-z {
+  syntax: "*";
+  inherits: false;
+  initial-value: 1;
 }
 @property --tw-rotate-x {
   syntax: "*";
@@ -1349,6 +2033,10 @@
   inherits: false;
 }
 @property --tw-font-weight {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-tracking {
   syntax: "*";
   inherits: false;
 }
@@ -1519,29 +2207,25 @@
   syntax: "*";
   inherits: false;
 }
-@property --tw-scale-x {
-  syntax: "*";
-  inherits: false;
-  initial-value: 1;
-}
-@property --tw-scale-y {
-  syntax: "*";
-  inherits: false;
-  initial-value: 1;
-}
-@property --tw-scale-z {
-  syntax: "*";
-  inherits: false;
-  initial-value: 1;
-}
 @keyframes spin {
   to {
     transform: rotate(360deg);
   }
 }
+@keyframes pulse {
+  50% {
+    opacity: 0.5;
+  }
+}
 @layer properties {
   @supports ((-webkit-hyphens: none) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color:rgb(from red r g b)))) {
     *, ::before, ::after, ::backdrop {
+      --tw-translate-x: 0;
+      --tw-translate-y: 0;
+      --tw-translate-z: 0;
+      --tw-scale-x: 1;
+      --tw-scale-y: 1;
+      --tw-scale-z: 1;
       --tw-rotate-x: initial;
       --tw-rotate-y: initial;
       --tw-rotate-z: initial;
@@ -1552,6 +2236,7 @@
       --tw-border-style: solid;
       --tw-leading: initial;
       --tw-font-weight: initial;
+      --tw-tracking: initial;
       --tw-shadow: 0 0 #0000;
       --tw-shadow-color: initial;
       --tw-shadow-alpha: 100%;
@@ -1591,9 +2276,6 @@
       --tw-backdrop-sepia: initial;
       --tw-duration: initial;
       --tw-ease: initial;
-      --tw-scale-x: 1;
-      --tw-scale-y: 1;
-      --tw-scale-z: 1;
     }
   }
 }


### PR DESCRIPTION
💡 What: Added informative tooltip icons next to the technical terms "Lazy Lasso" and "Edge Sensitivity" in the editor UI.
🎯 Why: To clarify the purpose of these technical settings for users without cluttering the interface with permanent helper text. Placing the tooltip on an `(i)` icon is clearer than placing it on the input slider itself.
📸 Before/After: The sliders previously had tooltips on hover, but no visual indicator that a tooltip existed. Now, there is a clear `(i)` icon next to the label that displays the tooltip on hover or focus.
♿ Accessibility: Ensured the new `(i)` icons are fully accessible to keyboard and screen reader users by adding `tabindex="0"`, `role="button"`, descriptive `aria-label`s, and `focus-visible` styling.

---
*PR created automatically by Jules for task [17801557672868083067](https://jules.google.com/task/17801557672868083067) started by @LokiMetaSmith*