### PR TITLE
fix: resolve duplicate `parser` declaration causing Vite build error

### DIFF
--- a/src/printshop.js
+++ b/src/printshop.js
@@ -1061,8 +1061,8 @@ async function handleNesting(e) {
                     reader.readAsDataURL(pngBlob);
                 });
 
-                const parser = new DOMParser();
-                const cutlineDoc = parser.parseFromString(cutlineSvgText, 'image/svg+xml');
+                const domParser = new DOMParser();
+                const cutlineDoc = domParser.parseFromString(cutlineSvgText, 'image/svg+xml');
                 const cutlineRoot = cutlineDoc.documentElement;
                 const width = cutlineRoot.getAttribute('width') || '100%';
                 const height = cutlineRoot.getAttribute('height') || '100%';
@@ -1134,8 +1134,8 @@ async function handleNesting(e) {
         window.currentCutFileId = cutFileId; // Save for download button
 
                 // 4. Inject Printing Marks & QR Codes into SVG
-                const parser = new DOMParser();
-                const svgDoc = parser.parseFromString(resultSvg, 'image/svg+xml');
+                const domParser = new DOMParser();
+                const svgDoc = domParser.parseFromString(resultSvg, 'image/svg+xml');
                 const rootSvg = svgDoc.documentElement;
 
                 const markShape = document.getElementById('alignmentMarkShape').value || 'circle';

--- a/tests/frontend/webauthn_client.test.js
+++ b/tests/frontend/webauthn_client.test.js
@@ -72,7 +72,7 @@ jest.unstable_mockModule('../../src/lib/svgparser.js', () => ({
     SVGParser: class {},
 }));
 jest.unstable_mockModule('../../src/lib/cut_file_generator.js', () => ({
-    generateCutFile: jest.fn(),
+    generateCutFile: jest.fn(), generatePltFile: jest.fn(),
 }));
 
 


### PR DESCRIPTION
Fixes a variable name collision where `parser` was re-declared, causing Vite to fail during dependency scan. Also resolves a failing unit test that required a mock for `generatePltFile`.

---
*PR created automatically by Jules for task [3037364471604115344](https://jules.google.com/task/3037364471604115344) started by @LokiMetaSmith*