### PR TITLE
🎨 Palette: Canvas Contrast Toggle

### DIFF
--- a/UX_TODO.md
+++ b/UX_TODO.md
@@ -20,7 +20,7 @@ This is a list of proposed UX improvements for the Print Shop interface, ordered
 - [ ] **Information Architecture:** Group settings better (e.g. "Shape/Size" for Magic Edge, "Detail/Smoothing" for Sensitivity and Lasso).
 - [x] **Tooltips:** Add (i) icons with tooltips explaining technical terms like "Lazy Lasso".
 - [ ] **Smart Presets:** Add preset buttons (Tight, Bubble, Smooth) for one-click configuration of edge and sensitivity sliders.
-- [ ] **Contrast Toggle:** Add a button to toggle the canvas background between light, dark, and transparent to help see edges better.
+- [x] **Contrast Toggle:** Add a button to toggle the canvas background between light, dark, and transparent to help see edges better.
 - [ ] **Manual Node Editing (Advanced):** Allow users to click and drag specific points on the generated path to tweak the cutline.
 
 ## New E-commerce & Printer Management Features (From Report)

--- a/index.html
+++ b/index.html
@@ -247,12 +247,26 @@
           <!-- Canvas & Layer Editor -->
           <div class="flex flex-col lg:flex-row gap-4 mb-6">
             <!-- Layer Editor Panel -->
-            <div id="layer-editor-panel" class="w-full lg:w-64 bg-white p-4 rounded-lg shadow border border-gray-200 flex flex-col" style="display: none;">
+            <div
+              id="layer-editor-panel"
+              class="w-full lg:w-64 bg-white p-4 rounded-lg shadow border border-gray-200 flex flex-col"
+              style="display: none"
+            >
               <div class="flex justify-between items-center mb-4">
                 <h3 class="font-bold text-gray-700">Stickers</h3>
-                <button type="button" id="add-layer-btn" class="bg-indigo-100 text-indigo-700 hover:bg-indigo-200 px-2 py-1 rounded text-sm font-semibold transition-colors" data-tooltip="Add another sticker to create a pack">+ Add</button>
+                <button
+                  type="button"
+                  id="add-layer-btn"
+                  class="bg-indigo-100 text-indigo-700 hover:bg-indigo-200 px-2 py-1 rounded text-sm font-semibold transition-colors"
+                  data-tooltip="Add another sticker to create a pack"
+                >
+                  + Add
+                </button>
               </div>
-              <ul id="layer-list" class="flex-grow overflow-y-auto flex flex-col gap-2 max-h-96">
+              <ul
+                id="layer-list"
+                class="flex-grow overflow-y-auto flex flex-col gap-2 max-h-96"
+              >
                 <!-- Populated by JS -->
               </ul>
             </div>
@@ -268,6 +282,52 @@
                 inputmode="none"
                 style="caret-color: transparent"
               >
+                <!-- Contrast Toggle Buttons -->
+                <div
+                  class="absolute top-2 right-2 z-30 flex gap-1 bg-white/90 p-1 rounded-md shadow-sm border border-gray-200"
+                  role="group"
+                  aria-label="Canvas Background Contrast"
+                >
+                  <button
+                    type="button"
+                    id="bgLightBtn"
+                    class="w-6 h-6 rounded border border-gray-300 bg-white hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-splotch-teal focus:outline-none"
+                    aria-label="Light Background"
+                    data-tooltip="Light Background"
+                  ></button>
+                  <button
+                    type="button"
+                    id="bgDarkBtn"
+                    class="w-6 h-6 rounded border border-gray-600 bg-gray-800 hover:bg-gray-900 focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-splotch-teal focus:outline-none"
+                    aria-label="Dark Background"
+                    data-tooltip="Dark Background"
+                  ></button>
+                  <button
+                    type="button"
+                    id="bgTransBtn"
+                    class="w-6 h-6 rounded border border-gray-300 focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-splotch-teal focus:outline-none relative overflow-hidden"
+                    aria-label="Checkerboard Background"
+                    data-tooltip="Checkerboard Background"
+                  >
+                    <div
+                      class="absolute inset-0 pointer-events-none"
+                      style="
+                        background-image:
+                          linear-gradient(45deg, #ccc 25%, transparent 25%),
+                          linear-gradient(135deg, #ccc 25%, transparent 25%),
+                          linear-gradient(45deg, transparent 75%, #ccc 75%),
+                          linear-gradient(135deg, transparent 75%, #ccc 75%);
+                        background-size: 8px 8px;
+                        background-position:
+                          0 0,
+                          4px 0,
+                          4px -4px,
+                          0px 4px;
+                        background-color: white;
+                      "
+                    ></div>
+                  </button>
+                </div>
                 <canvas
                   id="imageCanvas"
                   width="500"
@@ -562,9 +622,7 @@
               class="control-group-cutline grid grid-cols-1 sm:grid-cols-2 gap-6 p-4 bg-blue-50 rounded-lg"
               style="display: none"
             >
-              <div
-                class="flex flex-col justify-center items-center w-full"
-              >
+              <div class="flex flex-col justify-center items-center w-full">
                 <span class="text-xs text-gray-500 mb-1">Cut Shape</span>
                 <select
                   id="cutShapeSelect"
@@ -576,9 +634,7 @@
                 </select>
               </div>
 
-              <div
-                class="flex flex-col justify-center items-center w-full"
-              >
+              <div class="flex flex-col justify-center items-center w-full">
                 <label
                   for="cutlineOffsetSlider"
                   class="text-xs text-gray-500 mb-1"
@@ -603,9 +659,7 @@
               </div>
 
               <!-- Background Color Controls -->
-              <div
-                class="flex flex-col justify-center items-center w-full"
-              >
+              <div class="flex flex-col justify-center items-center w-full">
                 <span class="text-xs text-gray-500 mb-1">Background Color</span>
                 <div class="flex items-center gap-2">
                   <input
@@ -828,26 +882,66 @@
               class="w-full bg-white p-4 rounded shadow-sm border border-cyan-200 mt-4"
               style="display: none"
             >
-              <h3 class="text-lg font-semibold text-cyan-800 mb-3 flex items-center gap-2">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z" />
+              <h3
+                class="text-lg font-semibold text-cyan-800 mb-3 flex items-center gap-2"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="h-5 w-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"
+                  />
                 </svg>
                 Sheet Boundary Settings
               </h3>
               <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>
-                  <label for="boundaryShapeSelect" class="block text-sm font-medium text-gray-700 mb-1">Boundary Shape</label>
-                  <select id="boundaryShapeSelect" class="input w-full bg-white border border-gray-300 rounded-md shadow-sm px-3 py-2 text-sm focus:outline-none focus:ring-cyan-500 focus:border-cyan-500">
+                  <label
+                    for="boundaryShapeSelect"
+                    class="block text-sm font-medium text-gray-700 mb-1"
+                    >Boundary Shape</label
+                  >
+                  <select
+                    id="boundaryShapeSelect"
+                    class="input w-full bg-white border border-gray-300 rounded-md shadow-sm px-3 py-2 text-sm focus:outline-none focus:ring-cyan-500 focus:border-cyan-500"
+                  >
                     <option value="contour">Organic Contour</option>
                     <option value="square">Rectangle Box</option>
                     <option value="circle">Bounding Circle</option>
                   </select>
                 </div>
                 <div>
-                  <label for="boundaryMarginInput" class="block text-sm font-medium text-gray-700 mb-1">Bleed Margin (inches)</label>
+                  <label
+                    for="boundaryMarginInput"
+                    class="block text-sm font-medium text-gray-700 mb-1"
+                    >Bleed Margin (inches)</label
+                  >
                   <div class="flex items-center gap-2">
-                    <input type="range" id="boundaryMarginSlider" min="0" max="0.5" step="0.05" value="0" class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-cyan-600">
-                    <input type="number" id="boundaryMarginInput" min="0" max="0.5" step="0.05" value="0" class="input w-16 px-2 py-1 text-sm border border-gray-300 rounded-md">
+                    <input
+                      type="range"
+                      id="boundaryMarginSlider"
+                      min="0"
+                      max="0.5"
+                      step="0.05"
+                      value="0"
+                      class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-cyan-600"
+                    />
+                    <input
+                      type="number"
+                      id="boundaryMarginInput"
+                      min="0"
+                      max="0.5"
+                      step="0.05"
+                      value="0"
+                      class="input w-16 px-2 py-1 text-sm border border-gray-300 rounded-md"
+                    />
                   </div>
                 </div>
               </div>

--- a/src/ux-enhancements.js
+++ b/src/ux-enhancements.js
@@ -330,6 +330,41 @@ export function setupShortcutsHelp() {
   });
 }
 
+/**
+ * Sets up background contrast toggle buttons for the image canvas.
+ */
+export function setupContrastToggle() {
+  const canvas = document.getElementById("imageCanvas");
+  if (!canvas) return;
+
+  const bgLightBtn = document.getElementById("bgLightBtn");
+  const bgDarkBtn = document.getElementById("bgDarkBtn");
+  const bgTransBtn = document.getElementById("bgTransBtn");
+
+  const originalBgImage = canvas.style.backgroundImage;
+
+  if (bgLightBtn) {
+    bgLightBtn.addEventListener("click", () => {
+      canvas.style.backgroundImage = "none";
+      canvas.style.backgroundColor = "white";
+    });
+  }
+
+  if (bgDarkBtn) {
+    bgDarkBtn.addEventListener("click", () => {
+      canvas.style.backgroundImage = "none";
+      canvas.style.backgroundColor = "#1f2937"; // gray-800
+    });
+  }
+
+  if (bgTransBtn) {
+    bgTransBtn.addEventListener("click", () => {
+      canvas.style.backgroundImage = originalBgImage;
+      canvas.style.backgroundColor = "white";
+    });
+  }
+}
+
 // Initialize on load
 if (typeof document !== "undefined") {
   document.addEventListener("DOMContentLoaded", () => {
@@ -337,5 +372,6 @@ if (typeof document !== "undefined") {
     setupTooltips();
     setupKeyboardShortcuts();
     setupShortcutsHelp();
+    setupContrastToggle();
   });
 }


### PR DESCRIPTION
This PR implements the "Contrast Toggle" feature from `UX_TODO.md`.

It adds three small buttons (Light, Dark, Checkerboard) to the top right of the canvas. These buttons allow users to change the background color of the canvas on the fly, which is incredibly helpful when they upload an image that is primarily white or very dark, making it hard to see the cutlines or edges.

The buttons use existing Tailwind UI classes for consistent styling and `focus-visible` for proper keyboard accessibility. The implementation was placed alongside other UI improvements in `src/ux-enhancements.js`.

---
*PR created automatically by Jules for task [1201876057306142547](https://jules.google.com/task/1201876057306142547) started by @LokiMetaSmith*