### PR TITLE
Squash and flatten images to single high-res raster when exporting print files

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "js-yaml": "^4.1.1",
     "jsonwebtoken": "^9.0.2",
     "jspdf": "^4.1.0",
+    "jszip": "^3.10.1",
     "lowdb": "^7.0.1",
     "lusca": "^1.7.0",
     "multer": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       jspdf:
         specifier: ^4.1.0
         version: 4.1.0
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       lowdb:
         specifier: ^7.0.1
         version: 7.0.1
@@ -2702,6 +2705,9 @@ packages:
   core-js@3.48.0:
     resolution: {integrity: sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   cors@2.8.5:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
     engines: {node: '>= 0.10'}
@@ -2731,6 +2737,7 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
+    deprecated: v4 is no longer maintained, upgrade to v5
 
   cross-env@10.1.0:
     resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
@@ -3474,6 +3481,9 @@ packages:
     engines: {node: '>=16.x'}
     hasBin: true
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -3595,6 +3605,9 @@ packages:
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -3989,6 +4002,9 @@ packages:
   jspdf@4.1.0:
     resolution: {integrity: sha512-xd1d/XRkwqnsq6FP3zH1Q+Ejqn2ULIJeDZ+FTKpaabVpZREjsJKRJwuokTNgdqOU+fl55KgbvgZ1pRTSWCP2kQ==}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
 
@@ -4012,6 +4028,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lightningcss-android-arm64@1.30.2:
     resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
@@ -4683,6 +4702,9 @@ packages:
     resolution: {integrity: sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
@@ -4763,6 +4785,9 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
@@ -4877,6 +4902,9 @@ packages:
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -4937,6 +4965,9 @@ packages:
     resolution: {integrity: sha512-Qn/qMkzCcMFVPb60E/hQy+iRLpiU8PamOfOSYoAHmmF+fFFmpPpqa6Oci2iWYpTdOUM3VF+TINud7CfbQnsZbA==}
     engines: {node: '>= 14'}
     hasBin: true
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -5087,6 +5118,9 @@ packages:
   string-width@8.1.0:
     resolution: {integrity: sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==}
     engines: {node: '>=20'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -8425,6 +8459,8 @@ snapshots:
   core-js@3.48.0:
     optional: true
 
+  core-util-is@1.0.3: {}
+
   cors@2.8.5:
     dependencies:
       object-assign: 4.1.1
@@ -9297,6 +9333,8 @@ snapshots:
 
   image-size@2.0.2: {}
 
+  immediate@3.0.6: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -9396,6 +9434,8 @@ snapshots:
   is-wsl@2.2.0:
     dependencies:
       is-docker: 2.2.1
+
+  isarray@1.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -10294,6 +10334,13 @@ snapshots:
       dompurify: 3.3.1
       html2canvas: 1.4.1
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   jwa@2.0.1:
     dependencies:
       buffer-equal-constant-time: 1.0.1
@@ -10319,6 +10366,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lightningcss-android-arm64@1.30.2:
     optional: true
@@ -10843,6 +10894,8 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
+  process-nextick-args@2.0.1: {}
+
   process@0.11.10: {}
 
   prompts@2.4.2:
@@ -10915,6 +10968,16 @@ snapshots:
       strip-json-comments: 2.0.1
 
   react-is@18.3.1: {}
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
 
   readable-stream@3.6.2:
     dependencies:
@@ -11058,6 +11121,8 @@ snapshots:
 
   rrweb-cssom@0.8.0: {}
 
+  safe-buffer@5.1.2: {}
+
   safe-buffer@5.2.1: {}
 
   safe-compare@1.1.4:
@@ -11136,6 +11201,8 @@ snapshots:
       update-check: 1.5.4
     transitivePeerDependencies:
       - supports-color
+
+  setimmediate@1.0.5: {}
 
   setprototypeof@1.2.0: {}
 
@@ -11302,6 +11369,10 @@ snapshots:
     dependencies:
       get-east-asian-width: 1.4.0
       strip-ansi: 7.1.2
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   string_decoder@1.3.0:
     dependencies:

--- a/printshop.html
+++ b/printshop.html
@@ -546,7 +546,7 @@
                 id="exportPdfBtn"
                 class="mt-4 w-full px-4 py-2 bg-red-500 text-white rounded-md hover:bg-red-600"
               >
-                Export as PDF
+                Export Print Package (PDF/PNG)
               </button>
               <div
                 id="nested-svg-container"

--- a/src/printshop.js
+++ b/src/printshop.js
@@ -10,6 +10,7 @@ import { SVGParser } from "./lib/svgparser.js";
 import { generateCutFile, generatePltFile } from "./lib/cut_file_generator.js";
 import * as jose from "jose";
 import { jsPDF } from "jspdf";
+import JSZip from "jszip";
 import "svg2pdf.js";
 
 // --- Global Variables ---
@@ -1756,6 +1757,8 @@ async function handleExportPdf() {
 
   try {
     let doc = null;
+    const zip = new JSZip();
+    const baseName = window.currentCutFileId ? window.currentCutFileId : "nested-stickers";
 
     for (let i = 0; i < window.nestedSvgs.length; i++) {
         const svgElement = new DOMParser().parseFromString(
@@ -1785,8 +1788,44 @@ async function handleExportPdf() {
         // Stickers are PNG <image> tags, fiducials are <circle>/<rect>, QRs are <image>/<text>.
         svgElement.querySelectorAll('path, polygon, polyline, line').forEach(el => el.remove());
 
+        // Target 300 DPI (Default SVG scale is usually 96 DPI)
+        const scale = 300 / 96;
+        const targetWidth = Math.round(width * scale);
+        const targetHeight = Math.round(height * scale);
+
+        // Update SVG dimensions for crisp rendering onto canvas
+        svgElement.setAttribute("width", targetWidth);
+        svgElement.setAttribute("height", targetHeight);
+
+        // Serialize back to string
+        const svgString = new XMLSerializer().serializeToString(svgElement);
+        const svgBlob = new Blob([svgString], { type: "image/svg+xml;charset=utf-8" });
+        const url = URL.createObjectURL(svgBlob);
+
+        // Load into an Image
+        const img = new Image();
+        await new Promise((resolve, reject) => {
+            img.onload = resolve;
+            img.onerror = reject;
+            img.src = url;
+        });
+
+        // Draw to a scaled Canvas with white background
+        const canvas = document.createElement('canvas');
+        canvas.width = targetWidth;
+        canvas.height = targetHeight;
+        const ctx = canvas.getContext('2d');
+        ctx.fillStyle = '#FFFFFF';
+        ctx.fillRect(0, 0, targetWidth, targetHeight);
+        ctx.drawImage(img, 0, 0, targetWidth, targetHeight);
+        URL.revokeObjectURL(url);
+
+        // Get JPEG for PDF
+        const jpegDataUrl = canvas.toDataURL('image/jpeg', 0.95);
+
+        // Add to PDF
         if (i === 0) {
-            // Create the PDF with the correct dimensions from the start.
+            // Create the PDF with the correct original dimensions
             doc = new jsPDF({
               unit: "px",
               format: [width, height],
@@ -1795,19 +1834,32 @@ async function handleExportPdf() {
             doc.addPage([width, height]);
         }
 
-        await doc.svg(svgElement, {
-          x: 0,
-          y: 0,
-          width: width,
-          height: height,
-        });
+        doc.addImage(jpegDataUrl, 'JPEG', 0, 0, width, height);
+
+        // Get PNG Blob and add to zip
+        const pngBlob = await new Promise(resolve => canvas.toBlob(resolve, 'image/png'));
+        const sheetSuffix = window.nestedSvgs.length > 1 ? `-sheet${i + 1}` : '';
+        zip.file(`${baseName}${sheetSuffix}-300dpi.png`, pngBlob);
     }
 
-    const baseName = window.currentCutFileId ? window.currentCutFileId : "nested-stickers";
-    doc.save(`${baseName}.pdf`);
-    showSuccessToast("PDF exported successfully.");
+    // Add PDF to zip
+    const pdfBlob = doc.output('blob');
+    zip.file(`${baseName}-300dpi.pdf`, pdfBlob);
+
+    // Generate zip and trigger download
+    const zipBlob = await zip.generateAsync({ type: 'blob' });
+    const a = document.createElement("a");
+    const zipUrl = URL.createObjectURL(zipBlob);
+    a.href = zipUrl;
+    a.download = `${baseName}-print-package.zip`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(zipUrl);
+
+    showSuccessToast("Print package exported successfully.");
   } catch (error) {
-    showErrorToast(`PDF Export Failed: ${error.message}`);
+    showErrorToast(`Print Package Export Failed: ${error.message}`);
     console.error(error);
   }
 }

--- a/tests/frontend/pdf_export.test.js
+++ b/tests/frontend/pdf_export.test.js
@@ -13,8 +13,24 @@ global.HTMLAnchorElement = dom.window.HTMLAnchorElement;
 global.Node = dom.window.Node;
 global.URL = dom.window.URL;
 global.Blob = dom.window.Blob;
+class MockImage {
+    constructor() {
+        setTimeout(() => {
+            if (this.onload) this.onload();
+        }, 0);
+    }
+}
+global.Image = MockImage;
 global.XMLSerializer = dom.window.XMLSerializer;
 global.DOMParser = dom.window.DOMParser;
+global.HTMLCanvasElement = dom.window.HTMLCanvasElement;
+HTMLCanvasElement.prototype.getContext = jest.fn(() => ({
+    fillRect: jest.fn(),
+    drawImage: jest.fn(),
+    scale: jest.fn(),
+}));
+HTMLCanvasElement.prototype.toDataURL = jest.fn(() => 'data:image/jpeg;base64,mocked');
+HTMLCanvasElement.prototype.toBlob = jest.fn((cb) => cb(new Blob(['mocked'])));
 global.Text = dom.window.Text;
 
 // Mock localStorage
@@ -33,6 +49,9 @@ global.URL.revokeObjectURL = jest.fn();
 const docMock = {
     save: jest.fn(),
     svg: jest.fn(() => Promise.resolve()),
+    addImage: jest.fn(),
+    output: jest.fn(() => new Blob(['pdf-data'])),
+    addPage: jest.fn(),
 };
 
 const jsPDFMock = jest.fn(() => docMock);
@@ -44,6 +63,15 @@ jest.unstable_mockModule('jspdf', () => ({
 
 jest.unstable_mockModule('svg2pdf.js', () => ({
     default: jest.fn(),
+}));
+
+const mockZipFile = jest.fn();
+const mockZipGenerateAsync = jest.fn(() => Promise.resolve(new Blob(['mock-zip'])));
+jest.unstable_mockModule('jszip', () => ({
+    default: jest.fn().mockImplementation(() => ({
+        file: mockZipFile,
+        generateAsync: mockZipGenerateAsync,
+    }))
 }));
 
 // Mock other dependencies
@@ -111,13 +139,12 @@ describe('PDF Export Functionality', () => {
         await printshop.init();
     });
 
-    test('should call jsPDF and doc.svg when export button is clicked', async () => {
+    test('should call jsPDF, render canvas, and zip when export button is clicked', async () => {
         const btn = document.getElementById('exportPdfBtn');
-        // Trigger the click (it's async but returns a promise we can't await directly from click(), so we rely on mocks)
         btn.click();
 
         // Wait for async operations to complete
-        await new Promise(resolve => setTimeout(resolve, 10));
+        await new Promise(resolve => setTimeout(resolve, 50));
 
         expect(jsPDFMock).toHaveBeenCalledWith({
             unit: 'px',
@@ -125,15 +152,12 @@ describe('PDF Export Functionality', () => {
         });
 
         const docInstance = jsPDFMock.mock.results[0].value;
-        expect(docInstance.svg).toHaveBeenCalledWith(expect.anything(), {
-            x: 0,
-            y: 0,
-            width: 100,
-            height: 100
-        });
+        expect(docInstance.addImage).toHaveBeenCalledWith('data:image/jpeg;base64,mocked', 'JPEG', 0, 0, 100, 100);
 
-        // Verify save was called on the doc instance
-        expect(docInstance.save).toHaveBeenCalledWith('nested-stickers.pdf');
+        // Verify zip operations
+        expect(mockZipFile).toHaveBeenCalledWith('nested-stickers-300dpi.png', expect.any(Blob));
+        expect(mockZipFile).toHaveBeenCalledWith('nested-stickers-300dpi.pdf', expect.any(Blob));
+        expect(mockZipGenerateAsync).toHaveBeenCalled();
     });
 
     test('should show error if no nested SVG', async () => {

--- a/todo.md
+++ b/todo.md
@@ -1,3 +1,3 @@
 # To Do List
 
-- [ ] Squash the images down into a single image file when exporting. What that will look like is in the printshop software; it will need to generate cut files for the print server. We're using Mimaki's software which in theory has network constraints.
+- [x] Squash the images down into a single image file when exporting. What that will look like is in the printshop software; it will need to generate cut files for the print server. We're using Mimaki's software which in theory has network constraints.


### PR DESCRIPTION
This change modifies the `handleExportPdf` function in the printshop frontend to properly flatten nested SVG files before exporting them.

**Context:**
RIP software (like Mimaki's RasterLink) can easily crash or stall when processing complex PDFs containing thousands of vector nodes or nested transparencies. By rasterizing the artwork first, we guarantee print reliability.

**Key Changes:**
1. **DPI Scaling:** Since HTML `<canvas>` elements default to screen resolution (96 DPI), the SVGs are scaled up (by a factor of `300 / 96`) before drawing to ensure the print output is high quality (300 DPI).
2. **Flattening:** The clean SVG (with cut lines removed) is drawn to a white `<canvas>`, effectively flattening the image layers.
3. **Multi-Format Export & Zipping:** The system now extracts the rasterized canvas both as a JPEG (embedded into the output PDF) and as a raw PNG. `jszip` was added to bundle these files together into a single `-print-package.zip` for easier downloading and workflow integration.
4. **Testing:** Unit tests in `pdf_export.test.js` were updated to properly mock the required Canvas, Image, and JSZip objects.

---
*PR created automatically by Jules for task [10991864541955509252](https://jules.google.com/task/10991864541955509252) started by @LokiMetaSmith*